### PR TITLE
Add a bom module for easy downstream consumption.

### DIFF
--- a/neo4j-bolt-connection-bom/LICENSES.txt
+++ b/neo4j-bolt-connection-bom/LICENSES.txt
@@ -1,0 +1,5 @@
+This file contains the full license text of the included third party
+libraries. For an overview of the licenses see the NOTICE.txt file.
+
+
+

--- a/neo4j-bolt-connection-bom/NOTICE.txt
+++ b/neo4j-bolt-connection-bom/NOTICE.txt
@@ -1,0 +1,20 @@
+Copyright (c) "Neo4j"
+Neo4j Sweden AB [https://neo4j.com]
+
+This file is part of Neo4j.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Full license texts are found in LICENSES.txt.
+
+
+Third-party licenses
+--------------------
+

--- a/neo4j-bolt-connection-bom/pom.xml
+++ b/neo4j-bolt-connection-bom/pom.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.neo4j.bolt</groupId>
+        <artifactId>neo4j-bolt-connection-parent</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>neo4j-bolt-connection-bom</artifactId>
+
+    <packaging>pom</packaging>
+    <name>Neo4j Bolt Connection (BOM)</name>
+    <description>The BOM for the Neo4j Bolt Connection providers</description>
+
+    <properties>
+        <maven.deploy.skip>false</maven.deploy.skip>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.neo4j.bolt</groupId>
+                <artifactId>neo4j-bolt-connection</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.neo4j.bolt</groupId>
+                <artifactId>neo4j-bolt-connection-netty</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.neo4j.bolt</groupId>
+                <artifactId>neo4j-bolt-connection-pooled</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.neo4j.bolt</groupId>
+                <artifactId>neo4j-bolt-connection-routed</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>flatten-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>flatten</id>
+                        <goals>
+                            <goal>flatten</goal>
+                        </goals>
+                        <phase>process-resources</phase>
+                        <configuration>
+                            <updatePomFile>true</updatePomFile>
+                            <flattenMode>bom</flattenMode>
+                            <pomElements>
+                                <properties>remove</properties>
+                            </pomElements>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>flatten-clean</id>
+                        <goals>
+                            <goal>clean</goal>
+                        </goals>
+                        <phase>clean</phase>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/neo4j-bolt-connection-netty/pom.xml
+++ b/neo4j-bolt-connection-netty/pom.xml
@@ -20,6 +20,18 @@
         <surefire.jpms.args>--add-opens org.neo4j.bolt.connection.netty/org.neo4j.bolt.connection.netty.impl.util.messaging=ALL-UNNAMED</surefire.jpms.args>
     </properties>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.neo4j.bolt</groupId>
+                <artifactId>neo4j-bolt-connection-bom</artifactId>
+                <version>${project.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>io.netty</groupId>
@@ -32,7 +44,6 @@
         <dependency>
             <groupId>org.neo4j.bolt</groupId>
             <artifactId>neo4j-bolt-connection</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/neo4j-bolt-connection-pooled/pom.xml
+++ b/neo4j-bolt-connection-pooled/pom.xml
@@ -19,11 +19,22 @@
         <rootDir>${project.basedir}/..</rootDir>
     </properties>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.neo4j.bolt</groupId>
+                <artifactId>neo4j-bolt-connection-bom</artifactId>
+                <version>${project.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>org.neo4j.bolt</groupId>
             <artifactId>neo4j-bolt-connection</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/neo4j-bolt-connection-routed/pom.xml
+++ b/neo4j-bolt-connection-routed/pom.xml
@@ -19,11 +19,22 @@
         <rootDir>${project.basedir}/..</rootDir>
     </properties>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.neo4j.bolt</groupId>
+                <artifactId>neo4j-bolt-connection-bom</artifactId>
+                <version>${project.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>org.neo4j.bolt</groupId>
             <artifactId>neo4j-bolt-connection</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/neo4j-bolt-connection-test-values/pom.xml
+++ b/neo4j-bolt-connection-test-values/pom.xml
@@ -18,11 +18,22 @@
         <rootDir>${project.basedir}/..</rootDir>
     </properties>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.neo4j.bolt</groupId>
+                <artifactId>neo4j-bolt-connection-bom</artifactId>
+                <version>${project.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>org.neo4j.bolt</groupId>
             <artifactId>neo4j-bolt-connection</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/neo4j-bolt-connection/pom.xml
+++ b/neo4j-bolt-connection/pom.xml
@@ -19,6 +19,18 @@
         <rootDir>${project.basedir}/..</rootDir>
     </properties>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.neo4j.bolt</groupId>
+                <artifactId>neo4j-bolt-connection-bom</artifactId>
+                <version>${project.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>org.bouncycastle</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,7 @@
     </developers>
 
     <modules>
+        <module>neo4j-bolt-connection-bom</module>
         <module>neo4j-bolt-connection</module>
         <module>neo4j-bolt-connection-test-values</module>
         <module>neo4j-bolt-connection-netty</module>
@@ -106,6 +107,11 @@
         <pluginManagement>
             <plugins>
                 <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>flatten-maven-plugin</artifactId>
+                    <version>1.7.0</version>
+                </plugin>
+                <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>3.10.1</version>
@@ -139,12 +145,12 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-source-plugin</artifactId>
-                    <version>3.0.1</version>
+                    <version>3.3.1</version>
                     <executions>
                         <execution>
                             <id>attach-sources</id>
                             <goals>
-                                <goal>jar</goal>
+                                <goal>jar-no-fork</goal>
                             </goals>
                             <configuration>
                                 <archive>
@@ -184,7 +190,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-enforcer-plugin</artifactId>
-                    <version>3.0.0</version>
+                    <version>3.5.0</version>
                     <configuration>
                         <rules>
                             <RestrictImports>
@@ -368,15 +374,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>3.0.1</version>
-                <executions>
-                    <execution>
-                        <id>attach-sources</id>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
             <!-- Explicit deployment override for this artifact only. -->
             <plugin>


### PR DESCRIPTION
This change also updates the source-jar plugin and changes its goal to jar-no-fork to avoid running sort pom and others twice (which will fail with the generated flattened pom).

JDBC already changed to use the bom.