### PR TITLE
perf: Add optional type methods to `ValueFactory`

### DIFF
--- a/neo4j-bolt-connection-netty/src/test/java/org/neo4j/bolt/connection/netty/impl/handlers/HelloResponseHandlerTest.java
+++ b/neo4j-bolt-connection-netty/src/test/java/org/neo4j/bolt/connection/netty/impl/handlers/HelloResponseHandlerTest.java
@@ -99,7 +99,7 @@ class HelloResponseHandlerTest {
         var latestAuth = new CompletableFuture<Long>();
         var handler = new HelloResponseHandler(agentFuture, channel, mock(Clock.class), latestAuth);
 
-        var metadata = metadata(valueFactory.value(null), "bolt-x");
+        var metadata = metadata(valueFactory.value((Object) null), "bolt-x");
         assertThrows(BoltUntrustedServerException.class, () -> handler.onSuccess(metadata));
 
         assertTrue(agentFuture.isCompletedExceptionally()); // initialization failed
@@ -151,7 +151,7 @@ class HelloResponseHandlerTest {
         var latestAuth = new CompletableFuture<Long>();
         var handler = new HelloResponseHandler(agentFuture, channel, mock(Clock.class), latestAuth);
 
-        var metadata = metadata(SERVER_AGENT, valueFactory.value(null));
+        var metadata = metadata(SERVER_AGENT, valueFactory.value((Object) null));
         assertThrows(IllegalStateException.class, () -> handler.onSuccess(metadata));
 
         assertTrue(agentFuture.isCompletedExceptionally()); // initialization failed
@@ -209,7 +209,7 @@ class HelloResponseHandlerTest {
         var latestAuth = new CompletableFuture<Long>();
         var handler = new HelloResponseHandler(agentFuture, channel, mock(Clock.class), latestAuth);
 
-        var metadata = metadata(SERVER_AGENT, "bolt-x", valueFactory.value(null));
+        var metadata = metadata(SERVER_AGENT, "bolt-x", valueFactory.value((Object) null));
         handler.onSuccess(metadata);
 
         assertTrue(agentFuture.isDone() && !agentFuture.isCompletedExceptionally() && !agentFuture.isCancelled());
@@ -243,7 +243,7 @@ class HelloResponseHandlerTest {
         if (version == null) {
             result.put("server", null);
         } else if (version instanceof Value && ((Value) version).isNull()) {
-            result.put("server", valueFactory.value(null));
+            result.put("server", valueFactory.value((Object) null));
         } else {
             result.put("server", valueFactory.value(version.toString()));
         }

--- a/neo4j-bolt-connection-netty/src/test/java/org/neo4j/bolt/connection/netty/impl/messaging/MessageFormatTest.java
+++ b/neo4j-bolt-connection-netty/src/test/java/org/neo4j/bolt/connection/netty/impl/messaging/MessageFormatTest.java
@@ -64,8 +64,8 @@ class MessageFormatTest {
 
     @Test
     void shouldPackUnpackValidValues() {
-        assertSerializesValue(
-                valueFactory.value(Map.of("cat", valueFactory.value(null), "dog", valueFactory.value(null))));
+        assertSerializesValue(valueFactory.value(
+                Map.of("cat", valueFactory.value((Object) null), "dog", valueFactory.value((Object) null))));
         assertSerializesValue(
                 valueFactory.value(Map.of("k", valueFactory.value(12), "a", valueFactory.value("banana"))));
         assertSerializesValue(valueFactory.value(asList("k", 12, "a", "banana")));

--- a/neo4j-bolt-connection-netty/src/test/java/org/neo4j/bolt/connection/netty/impl/messaging/v3/MessageReaderV3Test.java
+++ b/neo4j-bolt-connection-netty/src/test/java/org/neo4j/bolt/connection/netty/impl/messaging/v3/MessageReaderV3Test.java
@@ -71,7 +71,8 @@ public class MessageReaderV3Test extends AbstractMessageReaderTestBase {
                 IgnoredMessage.IGNORED,
                 new SuccessMessage(new HashMap<>()),
                 record(valueFactory.value(1337L)),
-                record(valueFactory.value(List.of("cat", valueFactory.value(null), "dog", valueFactory.value(null)))),
+                record(valueFactory.value(
+                        List.of("cat", valueFactory.value((Object) null), "dog", valueFactory.value((Object) null)))),
                 record(valueFactory.value(List.of("k", valueFactory.value(12), "a", valueFactory.value("banana")))),
                 record(valueFactory.value(asList(
                         valueFactory.value("k"),

--- a/neo4j-bolt-connection-netty/src/test/java/org/neo4j/bolt/connection/netty/impl/messaging/v4/MessageReaderV4Test.java
+++ b/neo4j-bolt-connection-netty/src/test/java/org/neo4j/bolt/connection/netty/impl/messaging/v4/MessageReaderV4Test.java
@@ -71,7 +71,8 @@ public class MessageReaderV4Test extends AbstractMessageReaderTestBase {
                 IgnoredMessage.IGNORED,
                 new SuccessMessage(new HashMap<>()),
                 record(valueFactory.value(1337L)),
-                record(valueFactory.value(List.of("cat", valueFactory.value(null), "dog", valueFactory.value(null)))),
+                record(valueFactory.value(
+                        List.of("cat", valueFactory.value((Object) null), "dog", valueFactory.value((Object) null)))),
                 record(valueFactory.value(List.of("k", valueFactory.value(12), "a", valueFactory.value("banana")))),
                 record(valueFactory.value(asList(
                         valueFactory.value("k"),

--- a/neo4j-bolt-connection-netty/src/test/java/org/neo4j/bolt/connection/netty/impl/messaging/v41/MessageReaderV41Test.java
+++ b/neo4j-bolt-connection-netty/src/test/java/org/neo4j/bolt/connection/netty/impl/messaging/v41/MessageReaderV41Test.java
@@ -71,7 +71,8 @@ public class MessageReaderV41Test extends AbstractMessageReaderTestBase {
                 IgnoredMessage.IGNORED,
                 new SuccessMessage(new HashMap<>()),
                 record(valueFactory.value(1337L)),
-                record(valueFactory.value(List.of("cat", valueFactory.value(null), "dog", valueFactory.value(null)))),
+                record(valueFactory.value(
+                        List.of("cat", valueFactory.value((Object) null), "dog", valueFactory.value((Object) null)))),
                 record(valueFactory.value(List.of("k", valueFactory.value(12), "a", valueFactory.value("banana")))),
                 record(valueFactory.value(asList(
                         valueFactory.value("k"),

--- a/neo4j-bolt-connection-netty/src/test/java/org/neo4j/bolt/connection/netty/impl/messaging/v42/MessageReaderV42Test.java
+++ b/neo4j-bolt-connection-netty/src/test/java/org/neo4j/bolt/connection/netty/impl/messaging/v42/MessageReaderV42Test.java
@@ -71,7 +71,8 @@ public class MessageReaderV42Test extends AbstractMessageReaderTestBase {
                 IgnoredMessage.IGNORED,
                 new SuccessMessage(new HashMap<>()),
                 record(valueFactory.value(1337L)),
-                record(valueFactory.value(List.of("cat", valueFactory.value(null), "dog", valueFactory.value(null)))),
+                record(valueFactory.value(
+                        List.of("cat", valueFactory.value((Object) null), "dog", valueFactory.value((Object) null)))),
                 record(valueFactory.value(List.of("k", valueFactory.value(12), "a", valueFactory.value("banana")))),
                 record(valueFactory.value(asList(
                         valueFactory.value("k"),

--- a/neo4j-bolt-connection-netty/src/test/java/org/neo4j/bolt/connection/netty/impl/messaging/v43/MessageReaderV43Test.java
+++ b/neo4j-bolt-connection-netty/src/test/java/org/neo4j/bolt/connection/netty/impl/messaging/v43/MessageReaderV43Test.java
@@ -72,7 +72,8 @@ public class MessageReaderV43Test extends AbstractMessageReaderTestBase {
                 IgnoredMessage.IGNORED,
                 new SuccessMessage(new HashMap<>()),
                 record(valueFactory.value(1337L)),
-                record(valueFactory.value(List.of("cat", valueFactory.value(null), "dog", valueFactory.value(null)))),
+                record(valueFactory.value(
+                        List.of("cat", valueFactory.value((Object) null), "dog", valueFactory.value((Object) null)))),
                 record(valueFactory.value(List.of("k", valueFactory.value(12), "a", valueFactory.value("banana")))),
                 record(valueFactory.value(asList(
                         valueFactory.value("k"),

--- a/neo4j-bolt-connection-netty/src/test/java/org/neo4j/bolt/connection/netty/impl/messaging/v44/MessageReaderV44Test.java
+++ b/neo4j-bolt-connection-netty/src/test/java/org/neo4j/bolt/connection/netty/impl/messaging/v44/MessageReaderV44Test.java
@@ -70,7 +70,8 @@ public class MessageReaderV44Test extends AbstractMessageReaderTestBase {
                 IgnoredMessage.IGNORED,
                 new SuccessMessage(new HashMap<>()),
                 record(valueFactory.value(1337L)),
-                record(valueFactory.value(List.of("cat", valueFactory.value(null), "dog", valueFactory.value(null)))),
+                record(valueFactory.value(
+                        List.of("cat", valueFactory.value((Object) null), "dog", valueFactory.value((Object) null)))),
                 record(valueFactory.value(List.of("k", valueFactory.value(12), "a", valueFactory.value("banana")))),
                 record(valueFactory.value(asList(
                         valueFactory.value("k"),

--- a/neo4j-bolt-connection-netty/src/test/java/org/neo4j/bolt/connection/netty/impl/messaging/v5/MessageReaderV5Test.java
+++ b/neo4j-bolt-connection-netty/src/test/java/org/neo4j/bolt/connection/netty/impl/messaging/v5/MessageReaderV5Test.java
@@ -70,7 +70,8 @@ public class MessageReaderV5Test extends AbstractMessageReaderTestBase {
                 IgnoredMessage.IGNORED,
                 new SuccessMessage(new HashMap<>()),
                 record(valueFactory.value(1337L)),
-                record(valueFactory.value(List.of("cat", valueFactory.value(null), "dog", valueFactory.value(null)))),
+                record(valueFactory.value(
+                        List.of("cat", valueFactory.value((Object) null), "dog", valueFactory.value((Object) null)))),
                 record(valueFactory.value(List.of("k", valueFactory.value(12), "a", valueFactory.value("banana")))),
                 record(valueFactory.value(asList(
                         valueFactory.value("k"),

--- a/neo4j-bolt-connection-netty/src/test/java/org/neo4j/bolt/connection/netty/impl/messaging/v57/MessageReaderV57Test.java
+++ b/neo4j-bolt-connection-netty/src/test/java/org/neo4j/bolt/connection/netty/impl/messaging/v57/MessageReaderV57Test.java
@@ -67,7 +67,8 @@ class MessageReaderV57Test extends AbstractMessageReaderTestBase {
                 IgnoredMessage.IGNORED,
                 new SuccessMessage(new HashMap<>()),
                 record(valueFactory.value(1337L)),
-                record(valueFactory.value(List.of("cat", valueFactory.value(null), "dog", valueFactory.value(null)))),
+                record(valueFactory.value(
+                        List.of("cat", valueFactory.value((Object) null), "dog", valueFactory.value((Object) null)))),
                 record(valueFactory.value(List.of("k", valueFactory.value(12), "a", valueFactory.value("banana")))),
                 record(valueFactory.value(asList(
                         valueFactory.value("k"),

--- a/neo4j-bolt-connection-netty/src/test/java/org/neo4j/bolt/connection/netty/impl/util/MetadataExtractorTest.java
+++ b/neo4j-bolt-connection-netty/src/test/java/org/neo4j/bolt/connection/netty/impl/util/MetadataExtractorTest.java
@@ -76,7 +76,7 @@ class MetadataExtractorTest {
     void shouldFailToExtractServerVersionWhenMetadataDoesNotContainIt() {
         assertThrows(
                 BoltUntrustedServerException.class,
-                () -> extractServer(singletonMap("server", valueFactory.value(null))));
+                () -> extractServer(singletonMap("server", valueFactory.value((Object) null))));
         assertThrows(BoltUntrustedServerException.class, () -> extractServer(singletonMap("server", null)));
     }
 

--- a/neo4j-bolt-connection/src/main/java/org/neo4j/bolt/connection/values/ValueFactory.java
+++ b/neo4j-bolt-connection/src/main/java/org/neo4j/bolt/connection/values/ValueFactory.java
@@ -17,12 +17,92 @@
 package org.neo4j.bolt.connection.values;
 
 import java.time.DateTimeException;
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.OffsetTime;
+import java.time.Period;
+import java.time.ZonedDateTime;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
 public interface ValueFactory {
     Value value(Object value);
+
+    default Value value(boolean value) {
+        return value((Object) value);
+    }
+
+    default Value value(long value) {
+        return value((Object) value);
+    }
+
+    default Value value(double value) {
+        return value((Object) value);
+    }
+
+    default Value value(byte[] values) {
+        return value((Object) values);
+    }
+
+    default Value value(String value) {
+        return value((Object) value);
+    }
+
+    default Value value(Map<String, Value> stringToValue) {
+        return value((Object) stringToValue);
+    }
+
+    default Value value(Value[] values) {
+        return value((Object) values);
+    }
+
+    default Value value(Node node) {
+        return value((Object) node);
+    }
+
+    default Value value(Relationship relationship) {
+        return value((Object) relationship);
+    }
+
+    default Value value(Path path) {
+        return value((Object) path);
+    }
+
+    default Value value(LocalDate localDate) {
+        return value((Object) localDate);
+    }
+
+    default Value value(OffsetTime offsetTime) {
+        return value((Object) offsetTime);
+    }
+
+    default Value value(LocalTime localTime) {
+        return value((Object) localTime);
+    }
+
+    default Value value(LocalDateTime localDateTime) {
+        return value((Object) localDateTime);
+    }
+
+    default Value value(OffsetDateTime offsetDateTime) {
+        return value((Object) offsetDateTime);
+    }
+
+    default Value value(ZonedDateTime zonedDateTime) {
+        return value((Object) zonedDateTime);
+    }
+
+    default Value value(Period period) {
+        return value((Object) period);
+    }
+
+    default Value value(Duration duration) {
+        return value((Object) duration);
+    }
 
     Node node(long id, String elementId, Collection<String> labels, Map<String, Value> properties);
 


### PR DESCRIPTION
A typical implementation of `org.neo4j.bolt.connection.values.ValueFactory#value(java.lang.Object)` is likely to consist of a set of `if` blocks detecting types. Most implementations of connection provider would likely know the type that is actually needed and calling a dedicated method directly would be slightly more efficient. Therefore, this update adds `default` methods to `ValueFactory` to allow optional optimisation.