### PR TITLE
fix: Don't log stacktraces when channel is closed explicitly

### DIFF
--- a/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/async/connection/ChannelAttributes.java
+++ b/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/async/connection/ChannelAttributes.java
@@ -41,6 +41,7 @@ public final class ChannelAttributes {
             AttributeKey.valueOf("authorizationStateListener");
     private static final AttributeKey<Set<BoltPatchesListener>> BOLT_PATCHES_LISTENERS =
             AttributeKey.valueOf("boltPatchesListeners");
+    private static final AttributeKey<Boolean> CLOSING = AttributeKey.valueOf("closing");
 
     // configuration hints provided by the server
     private static final AttributeKey<Long> CONNECTION_READ_TIMEOUT = AttributeKey.valueOf("connectionReadTimeout");
@@ -158,6 +159,14 @@ public final class ChannelAttributes {
 
     public static boolean ssrEnabled(Channel channel) {
         return Optional.ofNullable(get(channel, SSR_ENABLED)).orElse(false);
+    }
+
+    public static void setClosing(Channel channel) {
+        setOnce(channel, CLOSING, true);
+    }
+
+    public static boolean isClosing(Channel channel) {
+        return Optional.ofNullable(get(channel, CLOSING)).orElse(false);
     }
 
     private static <T> T get(Channel channel, AttributeKey<T> key) {

--- a/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/async/inbound/InboundMessageDispatcher.java
+++ b/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/async/inbound/InboundMessageDispatcher.java
@@ -17,6 +17,7 @@
 package org.neo4j.bolt.connection.netty.impl.async.inbound;
 
 import static java.util.Objects.requireNonNull;
+import static org.neo4j.bolt.connection.netty.impl.async.connection.ChannelAttributes.isClosing;
 
 import io.netty.channel.Channel;
 import java.util.Arrays;
@@ -174,7 +175,9 @@ public class InboundMessageDispatcher implements ResponseMessageHandler {
             handler.onFailure(error);
         }
 
-        errorLog.traceOrDebug("Closing channel because of a failure", error);
+        if (!isClosing(channel)) {
+            errorLog.traceOrDebug("Closing channel because of a failure", error);
+        }
         this.channel.close();
     }
 

--- a/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/handlers/HelloResponseHandler.java
+++ b/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/handlers/HelloResponseHandler.java
@@ -19,6 +19,7 @@ package org.neo4j.bolt.connection.netty.impl.handlers;
 import static java.util.Objects.requireNonNull;
 import static org.neo4j.bolt.connection.netty.impl.async.connection.ChannelAttributes.boltPatchesListeners;
 import static org.neo4j.bolt.connection.netty.impl.async.connection.ChannelAttributes.protocolVersion;
+import static org.neo4j.bolt.connection.netty.impl.async.connection.ChannelAttributes.setClosing;
 import static org.neo4j.bolt.connection.netty.impl.async.connection.ChannelAttributes.setConnectionId;
 import static org.neo4j.bolt.connection.netty.impl.async.connection.ChannelAttributes.setConnectionReadTimeout;
 import static org.neo4j.bolt.connection.netty.impl.async.connection.ChannelAttributes.setServerAgent;
@@ -88,6 +89,7 @@ public class HelloResponseHandler implements ResponseHandler {
 
     @Override
     public void onFailure(Throwable error) {
+        setClosing(channel);
         channel.close().addListener(future -> this.future.completeExceptionally(error));
     }
 

--- a/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/handlers/HelloV51ResponseHandler.java
+++ b/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/handlers/HelloV51ResponseHandler.java
@@ -16,6 +16,7 @@
  */
 package org.neo4j.bolt.connection.netty.impl.handlers;
 
+import static org.neo4j.bolt.connection.netty.impl.async.connection.ChannelAttributes.setClosing;
 import static org.neo4j.bolt.connection.netty.impl.async.connection.ChannelAttributes.setConnectionId;
 import static org.neo4j.bolt.connection.netty.impl.async.connection.ChannelAttributes.setConnectionReadTimeout;
 import static org.neo4j.bolt.connection.netty.impl.async.connection.ChannelAttributes.setServerAgent;
@@ -66,6 +67,7 @@ public class HelloV51ResponseHandler implements ResponseHandler {
 
     @Override
     public void onFailure(Throwable error) {
+        setClosing(channel);
         channel.close().addListener(future -> helloFuture.completeExceptionally(error));
     }
 

--- a/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/handlers/LogonResponseHandler.java
+++ b/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/handlers/LogonResponseHandler.java
@@ -17,6 +17,7 @@
 package org.neo4j.bolt.connection.netty.impl.handlers;
 
 import static java.util.Objects.requireNonNull;
+import static org.neo4j.bolt.connection.netty.impl.async.connection.ChannelAttributes.setClosing;
 
 import io.netty.channel.Channel;
 import java.time.Clock;
@@ -49,6 +50,7 @@ public class LogonResponseHandler implements ResponseHandler {
     @Override
     public void onFailure(Throwable error) {
         if (channel != null) {
+            setClosing(channel);
             channel.close().addListener(future -> this.future.completeExceptionally(error));
         } else {
             future.completeExceptionally(error);


### PR DESCRIPTION
When `TRACE` level is enabled, a log statement with stacktrace is emitted for every closing channel. This may be very noisy. This update makes sure such entries are not emitted when the channel is closed explicitly.