### PR TITLE
refactor: Update BoltConnection#onLoop to accept Supplier

### DIFF
--- a/neo4j-bolt-connection-bom/pom.xml
+++ b/neo4j-bolt-connection-bom/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.neo4j.bolt</groupId>
         <artifactId>neo4j-bolt-connection-parent</artifactId>
-        <version>1.1-SNAPSHOT</version>
+        <version>2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>neo4j-bolt-connection-bom</artifactId>

--- a/neo4j-bolt-connection-netty/pom.xml
+++ b/neo4j-bolt-connection-netty/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.neo4j.bolt</groupId>
         <artifactId>neo4j-bolt-connection-parent</artifactId>
-        <version>1.1-SNAPSHOT</version>
+        <version>2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>neo4j-bolt-connection-netty</artifactId>

--- a/neo4j-bolt-connection-pooled/pom.xml
+++ b/neo4j-bolt-connection-pooled/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.neo4j.bolt</groupId>
         <artifactId>neo4j-bolt-connection-parent</artifactId>
-        <version>1.1-SNAPSHOT</version>
+        <version>2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>neo4j-bolt-connection-pooled</artifactId>

--- a/neo4j-bolt-connection-pooled/src/main/java/org/neo4j/bolt/connection/pooled/impl/PooledBoltConnection.java
+++ b/neo4j-bolt-connection-pooled/src/main/java/org/neo4j/bolt/connection/pooled/impl/PooledBoltConnection.java
@@ -23,6 +23,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.function.Supplier;
 import org.neo4j.bolt.connection.AccessMode;
 import org.neo4j.bolt.connection.AuthInfo;
 import org.neo4j.bolt.connection.AuthToken;
@@ -70,8 +71,8 @@ public class PooledBoltConnection implements BoltConnection {
     }
 
     @Override
-    public CompletionStage<BoltConnection> onLoop() {
-        return delegate.onLoop();
+    public <T> CompletionStage<T> onLoop(Supplier<T> supplier) {
+        return delegate.onLoop(supplier);
     }
 
     @Override

--- a/neo4j-bolt-connection-routed/pom.xml
+++ b/neo4j-bolt-connection-routed/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.neo4j.bolt</groupId>
         <artifactId>neo4j-bolt-connection-parent</artifactId>
-        <version>1.1-SNAPSHOT</version>
+        <version>2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>neo4j-bolt-connection-routed</artifactId>

--- a/neo4j-bolt-connection-routed/src/main/java/org/neo4j/bolt/connection/routed/impl/RoutedBoltConnection.java
+++ b/neo4j-bolt-connection-routed/src/main/java/org/neo4j/bolt/connection/routed/impl/RoutedBoltConnection.java
@@ -24,6 +24,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletionStage;
+import java.util.function.Supplier;
 import org.neo4j.bolt.connection.AccessMode;
 import org.neo4j.bolt.connection.AuthInfo;
 import org.neo4j.bolt.connection.AuthToken;
@@ -72,8 +73,8 @@ public class RoutedBoltConnection implements BoltConnection {
     }
 
     @Override
-    public CompletionStage<BoltConnection> onLoop() {
-        return delegate.onLoop();
+    public <T> CompletionStage<T> onLoop(Supplier<T> supplier) {
+        return delegate.onLoop(supplier);
     }
 
     @Override

--- a/neo4j-bolt-connection-test-values/pom.xml
+++ b/neo4j-bolt-connection-test-values/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.neo4j.bolt</groupId>
         <artifactId>neo4j-bolt-connection-parent</artifactId>
-        <version>1.1-SNAPSHOT</version>
+        <version>2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>neo4j-bolt-connection-test-values</artifactId>

--- a/neo4j-bolt-connection/pom.xml
+++ b/neo4j-bolt-connection/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.neo4j.bolt</groupId>
         <artifactId>neo4j-bolt-connection-parent</artifactId>
-        <version>1.1-SNAPSHOT</version>
+        <version>2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>neo4j-bolt-connection</artifactId>

--- a/neo4j-bolt-connection/src/main/java/org/neo4j/bolt/connection/BoltConnection.java
+++ b/neo4j-bolt-connection/src/main/java/org/neo4j/bolt/connection/BoltConnection.java
@@ -21,10 +21,11 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletionStage;
+import java.util.function.Supplier;
 import org.neo4j.bolt.connection.values.Value;
 
 public interface BoltConnection {
-    CompletionStage<BoltConnection> onLoop();
+    <T> CompletionStage<T> onLoop(Supplier<T> supplier);
 
     CompletionStage<BoltConnection> route(DatabaseName databaseName, String impersonatedUser, Set<String> bookmarks);
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.neo4j.bolt</groupId>
     <artifactId>neo4j-bolt-connection-parent</artifactId>
-    <version>1.1-SNAPSHOT</version>
+    <version>2.0-SNAPSHOT</version>
 
     <packaging>pom</packaging>
     <name>Neo4j Bolt Connection</name>


### PR DESCRIPTION
BREAKING CHANGE: The `BoltConnection#onLoop` method now requires a `Supplier`.

The updated method ensures that the provided `Supplier` is executed on the connection's `Thread` (if applicable to implementation). Previously, the logic of such supplier would have to be chained on the resulting `CompletionStage` and doing so does not guarantee that such logic would be executed exclusively by the assigned thread. For example, if one thread is still building the async chain when the stage is completed by the other thread, a change of thread may happen.