### PR TITLE
feat(bolt): Export org.neo4j.bolt.connection.netty

### DIFF
--- a/neo4j-bolt-connection-netty/src/main/java/module-info.java
+++ b/neo4j-bolt-connection-netty/src/main/java/module-info.java
@@ -22,6 +22,8 @@ module org.neo4j.bolt.connection.netty {
     provides org.neo4j.bolt.connection.BoltConnectionProviderFactory with
             org.neo4j.bolt.connection.netty.NettyBoltConnectionProviderFactory;
 
+    exports org.neo4j.bolt.connection.netty;
+
     requires org.neo4j.bolt.connection;
     requires io.netty.common;
     requires io.netty.handler;

--- a/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/NettyBoltConnectionProviderFactory.java
+++ b/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/NettyBoltConnectionProviderFactory.java
@@ -28,6 +28,8 @@ import org.neo4j.bolt.connection.DefaultDomainNameResolver;
 import org.neo4j.bolt.connection.DomainNameResolver;
 import org.neo4j.bolt.connection.LoggingProvider;
 import org.neo4j.bolt.connection.MetricsListener;
+import org.neo4j.bolt.connection.netty.impl.BootstrapFactory;
+import org.neo4j.bolt.connection.netty.impl.NettyBoltConnectionProvider;
 import org.neo4j.bolt.connection.values.ValueFactory;
 
 public final class NettyBoltConnectionProviderFactory implements BoltConnectionProviderFactory {

--- a/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/BootstrapFactory.java
+++ b/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/BootstrapFactory.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.neo4j.bolt.connection.netty;
+package org.neo4j.bolt.connection.netty.impl;
 
 import io.netty.bootstrap.Bootstrap;
 import io.netty.channel.ChannelOption;

--- a/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/EventLoopThread.java
+++ b/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/EventLoopThread.java
@@ -14,6 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.neo4j.bolt.connection.netty;
+package org.neo4j.bolt.connection.netty.impl;
 
 public interface EventLoopThread {}

--- a/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/NettyBoltConnectionProvider.java
+++ b/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/NettyBoltConnectionProvider.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.neo4j.bolt.connection.netty;
+package org.neo4j.bolt.connection.netty.impl;
 
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.local.LocalAddress;
@@ -40,11 +40,6 @@ import org.neo4j.bolt.connection.RoutingContext;
 import org.neo4j.bolt.connection.SecurityPlan;
 import org.neo4j.bolt.connection.exception.BoltClientException;
 import org.neo4j.bolt.connection.exception.MinVersionAcquisitionException;
-import org.neo4j.bolt.connection.netty.impl.BoltConnectionImpl;
-import org.neo4j.bolt.connection.netty.impl.ConnectionProvider;
-import org.neo4j.bolt.connection.netty.impl.ConnectionProviders;
-import org.neo4j.bolt.connection.netty.impl.NettyLogging;
-import org.neo4j.bolt.connection.netty.impl.NoopMetricsListener;
 import org.neo4j.bolt.connection.netty.impl.util.FutureUtil;
 import org.neo4j.bolt.connection.values.ValueFactory;
 

--- a/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/async/connection/EventLoopGroupFactory.java
+++ b/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/async/connection/EventLoopGroupFactory.java
@@ -26,7 +26,7 @@ import io.netty.util.concurrent.FastThreadLocalThread;
 import java.util.Objects;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ThreadFactory;
-import org.neo4j.bolt.connection.netty.EventLoopThread;
+import org.neo4j.bolt.connection.netty.impl.EventLoopThread;
 
 /**
  * Manages creation of Netty {@link EventLoopGroup}s, which are basically {@link Executor}s that perform IO operations.

--- a/neo4j-bolt-connection/src/main/java/org/neo4j/bolt/connection/BoltConnectionProviderFactory.java
+++ b/neo4j-bolt-connection/src/main/java/org/neo4j/bolt/connection/BoltConnectionProviderFactory.java
@@ -22,7 +22,7 @@ import org.neo4j.bolt.connection.values.ValueFactory;
 /**
  * A factory for creating instances of {@link BoltConnectionProvider}.
  * <p>
- * It should be discovered using the {@link java.util.ServiceLoader}.
+ * Implementations MUST be loadable by the {@link java.util.ServiceLoader}.
  * @since 4.0.0
  */
 public interface BoltConnectionProviderFactory {


### PR DESCRIPTION
This update exports the `org.neo4j.bolt.connection.netty` package in the `org.neo4j.bolt.connection.netty` module. This allows the factory to be used directly when needed.