### PR TITLE
feat(agent): remove serverAgent validation

### DIFF
--- a/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/util/MetadataExtractor.java
+++ b/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/util/MetadataExtractor.java
@@ -70,11 +70,6 @@ public class MetadataExtractor {
         if (versionValue == null || versionValue.isNull()) {
             throw new BoltUntrustedServerException("Server provides no product identifier");
         }
-        var serverAgent = versionValue.asString();
-        if (!serverAgent.startsWith("Neo4j/")) {
-            throw new BoltUntrustedServerException(
-                    "Server does not identify as a genuine Neo4j instance: '" + serverAgent + "'");
-        }
         return versionValue;
     }
 

--- a/neo4j-bolt-connection-netty/src/test/java/org/neo4j/bolt/connection/netty/impl/handlers/HelloResponseHandlerTest.java
+++ b/neo4j-bolt-connection-netty/src/test/java/org/neo4j/bolt/connection/netty/impl/handlers/HelloResponseHandlerTest.java
@@ -107,19 +107,6 @@ class HelloResponseHandlerTest {
     }
 
     @Test
-    void shouldThrowWhenServerAgentIsUnrecognised() {
-        var agentFuture = new CompletableFuture<String>();
-        var latestAuth = new CompletableFuture<Long>();
-        var handler = new HelloResponseHandler(agentFuture, channel, mock(Clock.class), latestAuth);
-
-        var metadata = metadata("WrongServerVersion", "bolt-x");
-        assertThrows(BoltUntrustedServerException.class, () -> handler.onSuccess(metadata));
-
-        assertTrue(agentFuture.isCompletedExceptionally()); // initialization failed
-        assertTrue(channel.closeFuture().isDone()); // channel was closed
-    }
-
-    @Test
     void shouldSetConnectionIdOnChannel() {
         var agentFuture = new CompletableFuture<String>();
         var latestAuth = new CompletableFuture<Long>();

--- a/neo4j-bolt-connection-netty/src/test/java/org/neo4j/bolt/connection/netty/impl/util/MetadataExtractorTest.java
+++ b/neo4j-bolt-connection-netty/src/test/java/org/neo4j/bolt/connection/netty/impl/util/MetadataExtractorTest.java
@@ -79,11 +79,4 @@ class MetadataExtractorTest {
                 () -> extractServer(singletonMap("server", valueFactory.value((Object) null))));
         assertThrows(BoltUntrustedServerException.class, () -> extractServer(singletonMap("server", null)));
     }
-
-    @Test
-    void shouldFailToExtractServerVersionFromNonNeo4jProduct() {
-        assertThrows(
-                BoltUntrustedServerException.class,
-                () -> extractServer(singletonMap("server", valueFactory.value("NotNeo4j/1.2.3"))));
-    }
 }


### PR DESCRIPTION
This update removes the `serverAgent`.