### PR TITLE
feat(queryapi): add support for setting default database

### DIFF
--- a/neo4j-bolt-connection-query-api/src/main/java/org/neo4j/bolt/connection/query_api/impl/BeginMessageHandler.java
+++ b/neo4j-bolt-connection-query-api/src/main/java/org/neo4j/bolt/connection/query_api/impl/BeginMessageHandler.java
@@ -41,6 +41,7 @@ final class BeginMessageHandler extends AbstractMessageHandler<TransactionInfo> 
             ResponseHandler handler,
             HttpContext httpContext,
             BeginMessage message,
+            String defaultDatabase,
             ValueFactory valueFactory,
             LoggingProvider logging) {
         super(httpContext, handler, valueFactory, logging);
@@ -50,6 +51,8 @@ final class BeginMessageHandler extends AbstractMessageHandler<TransactionInfo> 
 
         if (message.databaseName().isPresent()) {
             this.databaseName = message.databaseName().get();
+        } else if (defaultDatabase != null) {
+            this.databaseName = defaultDatabase;
         } else {
             throw new BoltClientException("Database name must be specified");
         }

--- a/neo4j-bolt-connection-query-api/src/main/java/org/neo4j/bolt/connection/query_api/impl/RunMessageHandler.java
+++ b/neo4j-bolt-connection-query-api/src/main/java/org/neo4j/bolt/connection/query_api/impl/RunMessageHandler.java
@@ -48,12 +48,14 @@ final class RunMessageHandler extends AbstractMessageHandler<Query> {
     private final RunMessage message;
     private final Supplier<TransactionInfo> transactionInfoSupplier;
     private final AtomicReference<String> databaseName = new AtomicReference<>();
+    private final String defaultDatabase;
 
     RunMessageHandler(
             ResponseHandler handler,
             HttpContext httpContext,
             ValueFactory valueFactory,
             RunMessage message,
+            String defaultDatabase,
             Supplier<TransactionInfo> transactionInfoSupplier,
             LoggingProvider logging) {
         super(httpContext, handler, valueFactory, logging);
@@ -66,11 +68,12 @@ final class RunMessageHandler extends AbstractMessageHandler<Query> {
 
         if (message.extra().isPresent()) {
             var extra = message.extra().get();
-            if (extra.databaseName().isEmpty()) {
+            if (extra.databaseName().isEmpty() && defaultDatabase == null) {
                 throw new BoltClientException("Database name must be specified");
             }
         }
         this.bodyPublisher = newHttpRequestBodyPublisher(httpContext.json(), message);
+        this.defaultDatabase = defaultDatabase;
     }
 
     @Override
@@ -89,7 +92,7 @@ final class RunMessageHandler extends AbstractMessageHandler<Query> {
             }
         } else {
             databaseName =
-                    message.extra().flatMap(extra -> extra.databaseName()).orElse(null);
+                    message.extra().flatMap(extra -> extra.databaseName()).orElse(defaultDatabase);
             if (databaseName == null) {
                 throw new BoltClientException("Database not specified");
             }


### PR DESCRIPTION
This update adds support for setting a default database that should be used when no explicit database name is provided in `BEGIN` and autocommit `RUN` messages. This support is experimental and may be removed without any notice.