### PR TITLE
feat(queryapi): add support for setting default database

### DIFF
--- a/neo4j-bolt-connection-query-api/src/main/java/org/neo4j/bolt/connection/query_api/impl/BeginMessageHandler.java
+++ b/neo4j-bolt-connection-query-api/src/main/java/org/neo4j/bolt/connection/query_api/impl/BeginMessageHandler.java
@@ -50,6 +50,8 @@ final class BeginMessageHandler extends AbstractMessageHandler<TransactionInfo> 
 
         if (message.databaseName().isPresent()) {
             this.databaseName = message.databaseName().get();
+        } else if (httpContext.defaultDatabase() != null) {
+            this.databaseName = httpContext.defaultDatabase();
         } else {
             throw new BoltClientException("Database name must be specified");
         }

--- a/neo4j-bolt-connection-query-api/src/test/java/org/neo4j/bolt/connection/query_api/impl/HttpContextTest.java
+++ b/neo4j-bolt-connection-query-api/src/test/java/org/neo4j/bolt/connection/query_api/impl/HttpContextTest.java
@@ -40,7 +40,7 @@ class HttpContextTest {
             })
     void shouldNormalizeBase(URI uri) {
 
-        var httpContext = new HttpContext(HttpClient.newHttpClient(), uri, JSON.std, new String[] {});
+        var httpContext = new HttpContext(HttpClient.newHttpClient(), uri, JSON.std, new String[] {}, null);
         var expected = uri.toString() + (uri.toString().endsWith("/") ? "" : "/") + "db/foo/query/v2";
         Assertions.assertEquals(expected, httpContext.queryUrl("foo").toString());
     }
@@ -48,9 +48,24 @@ class HttpContextTest {
     @Test
     void txUrlShouldWork() {
         var httpContext = new HttpContext(
-                HttpClient.newHttpClient(), URI.create("http://localhost:7474"), JSON.std, new String[] {});
+                HttpClient.newHttpClient(), URI.create("http://localhost:7474"), JSON.std, new String[] {}, null);
         Assertions.assertEquals(
                 "http://localhost:7474/db/ads/query/v2/tx",
                 httpContext.txUrl("ads").toString());
+    }
+
+    @Test
+    void shouldParseDefaultDatabase() {
+        var httpContext = new HttpContext(
+                HttpClient.newHttpClient(),
+                URI.create("http://localhost:7474?defaultDatabase=neo4j&ignored=value"),
+                JSON.std,
+                new String[] {},
+                null);
+
+        Assertions.assertEquals("neo4j", httpContext.defaultDatabase());
+        Assertions.assertEquals(
+                "http://localhost:7474/db/foo/query/v2",
+                httpContext.queryUrl("foo").toString());
     }
 }


### PR DESCRIPTION
This update adds support for setting a default database that should be used when no explicit database name is provided in `BEGIN` and autocommit `RUN` messages. This support is experimental and may be removed without any notice.

The experimental default database name is parsed from the connection's `URI#getQuery()` part using `defaultDatabase` parameter. Note that both `URI#getQuery()` and `URI#getFragment()` are ignored when establishing connection as they are not supported at the moment.

Example: `http://localhost:7474?defaultDatabase=neo4j` URI will result in `neo4j` default datbase name being used.