### PR TITLE
feat(ssr): update serverSideRoutingEnabled handling

### DIFF
--- a/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/BoltConnectionImpl.java
+++ b/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/BoltConnectionImpl.java
@@ -113,7 +113,7 @@ public final class BoltConnectionImpl implements BoltConnection {
         this.serverAddress = Objects.requireNonNull(connection.serverAddress());
         this.protocolVersion = Objects.requireNonNull(connection.protocol().version());
         this.telemetrySupported = connection.isTelemetryEnabled();
-        this.serverSideRouting = connection.isSsrEnabled();
+        this.serverSideRouting = routingContext.isServerRoutingEnabled() && connection.isSsrEnabled();
         this.authDataRef = new AtomicReference<>(
                 CompletableFuture.completedFuture(new AuthInfoImpl(authToken, latestAuthMillisFuture.join())));
         this.valueFactory = Objects.requireNonNull(valueFactory);

--- a/neo4j-bolt-connection-query-api/src/main/java/org/neo4j/bolt/connection/query_api/impl/QueryApiBoltConnection.java
+++ b/neo4j-bolt-connection-query-api/src/main/java/org/neo4j/bolt/connection/query_api/impl/QueryApiBoltConnection.java
@@ -192,7 +192,7 @@ public final class QueryApiBoltConnection implements BoltConnection {
 
     @Override
     public boolean serverSideRoutingEnabled() {
-        return false;
+        return true;
     }
 
     @Override

--- a/neo4j-bolt-connection/src/main/java/org/neo4j/bolt/connection/BoltConnection.java
+++ b/neo4j-bolt-connection/src/main/java/org/neo4j/bolt/connection/BoltConnection.java
@@ -59,6 +59,17 @@ public interface BoltConnection {
 
     boolean telemetrySupported();
 
+    /**
+     * Returns whether server-side routing is enabled for this connection.
+     * <p>
+     * Since this may only be detected reliably from Bolt 5.8 and higher, it may return {@code false} for previous Bolt
+     * versions even if server-side routing is enabled.
+     * <p>
+     * In addition, this MUST return {@code false} when no routing context is sent to the server. The absense of routing
+     * context prohibits server-side routing from routing even if it is enabled on the server.
+     *
+     * @return {@code true} if enabled, {@code false} otherwise
+     */
     boolean serverSideRoutingEnabled();
 
     Optional<Duration> defaultReadTimeout();


### PR DESCRIPTION
BREAKING CHANGE: `BoltConnection.serverSideRoutingEnabled()` will take routing context into account when reporting if server-side routing is enabled for a given connection. In addition, Query API connection will report server-side routing to be enabled as it is expected to route messages accordingly and error handling should be fit for routing.