### PR TITLE
feat(queryapi): add support for LOGOFF and LOGON messages

### DIFF
--- a/neo4j-bolt-connection-query-api/src/main/java/org/neo4j/bolt/connection/query_api/QueryApiBoltConnectionProviderFactory.java
+++ b/neo4j-bolt-connection-query-api/src/main/java/org/neo4j/bolt/connection/query_api/QueryApiBoltConnectionProviderFactory.java
@@ -16,6 +16,7 @@
  */
 package org.neo4j.bolt.connection.query_api;
 
+import java.time.Clock;
 import java.util.Map;
 import java.util.Set;
 import org.neo4j.bolt.connection.BoltConnectionProvider;
@@ -52,6 +53,15 @@ public final class QueryApiBoltConnectionProviderFactory implements BoltConnecti
             ValueFactory valueFactory,
             MetricsListener metricsListener,
             Map<String, ?> additionalConfig) {
-        return new QueryApiBoltConnectionProvider(loggingProvider, valueFactory);
+        return new QueryApiBoltConnectionProvider(loggingProvider, valueFactory, getClock(additionalConfig));
+    }
+
+    private Clock getClock(Map<String, ?> additionalConfig) {
+        var value = additionalConfig.get("clock");
+        if (value instanceof Clock clock) {
+            return clock;
+        } else {
+            return Clock.systemUTC();
+        }
     }
 }

--- a/neo4j-bolt-connection-query-api/src/main/java/org/neo4j/bolt/connection/query_api/impl/CommitMessageHandler.java
+++ b/neo4j-bolt-connection-query-api/src/main/java/org/neo4j/bolt/connection/query_api/impl/CommitMessageHandler.java
@@ -32,11 +32,13 @@ final class CommitMessageHandler extends AbstractMessageHandler<Void> {
     private final System.Logger log;
     private final ResponseHandler handler;
     private final HttpContext httpContext;
+    private final Supplier<String> authHeaderSupplier;
     private final Supplier<TransactionInfo> transactionInfoSupplier;
 
     CommitMessageHandler(
             ResponseHandler handler,
             HttpContext httpContext,
+            Supplier<String> authHeaderSupplier,
             ValueFactory valueFactory,
             Supplier<TransactionInfo> transactionInfoSupplier,
             LoggingProvider logging) {
@@ -44,6 +46,7 @@ final class CommitMessageHandler extends AbstractMessageHandler<Void> {
         this.log = logging.getLog(getClass());
         this.handler = Objects.requireNonNull(handler);
         this.httpContext = Objects.requireNonNull(httpContext);
+        this.authHeaderSupplier = Objects.requireNonNull(authHeaderSupplier);
         this.transactionInfoSupplier = Objects.requireNonNull(transactionInfoSupplier);
     }
 
@@ -53,7 +56,7 @@ final class CommitMessageHandler extends AbstractMessageHandler<Void> {
         if (transactionInfo == null) {
             throw new BoltClientException("No transaction found");
         }
-        var headers = httpContext.headers();
+        var headers = httpContext.headers(authHeaderSupplier.get());
         if (transactionInfo.affinity() != null) {
             headers = Arrays.copyOf(headers, headers.length + 2);
             headers[headers.length - 2] = "neo4j-cluster-affinity";

--- a/neo4j-bolt-connection-query-api/src/main/java/org/neo4j/bolt/connection/query_api/impl/HttpContext.java
+++ b/neo4j-bolt-connection-query-api/src/main/java/org/neo4j/bolt/connection/query_api/impl/HttpContext.java
@@ -23,7 +23,7 @@ import java.net.http.HttpClient;
 import java.util.Objects;
 import org.neo4j.bolt.connection.exception.BoltClientException;
 
-public record HttpContext(HttpClient httpClient, URI baseUri, JSON json, String[] headers, String defaultDatabase) {
+public record HttpContext(HttpClient httpClient, URI baseUri, JSON json, String defaultDatabase, String userAgent) {
     // experimental
     private static final String DEFAULT_DATABASE_KEY_NAME = "defaultDatabase";
 
@@ -55,8 +55,12 @@ public record HttpContext(HttpClient httpClient, URI baseUri, JSON json, String[
         }
     }
 
-    public HttpContext(HttpClient httpClient, URI baseUri, JSON json, String authHeader, String userAgent) {
-        this(httpClient, baseUri, json, headers(authHeader, userAgent), null);
+    public HttpContext(HttpClient httpClient, URI baseUri, JSON json, String userAgent) {
+        this(httpClient, baseUri, json, null, userAgent);
+    }
+
+    public String[] headers(String authHeader) {
+        return headers(authHeader, userAgent);
     }
 
     private static String[] headers(String authHeader, String userAgent) {

--- a/neo4j-bolt-connection-query-api/src/main/java/org/neo4j/bolt/connection/query_api/impl/LogoffMessageHandler.java
+++ b/neo4j-bolt-connection-query-api/src/main/java/org/neo4j/bolt/connection/query_api/impl/LogoffMessageHandler.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.bolt.connection.query_api.impl;
+
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import org.neo4j.bolt.connection.ResponseHandler;
+
+final class LogoffMessageHandler implements MessageHandler<Void> {
+    private final ResponseHandler handler;
+
+    LogoffMessageHandler(ResponseHandler handler) {
+        this.handler = Objects.requireNonNull(handler);
+    }
+
+    @Override
+    public CompletionStage<Void> exchange() {
+        return CompletableFuture.<Void>completedStage(null).thenApply(ignored -> {
+            handler.onLogoffSummary(LogoffSummaryImpl.INSTANCE);
+            return null;
+        });
+    }
+}

--- a/neo4j-bolt-connection-query-api/src/main/java/org/neo4j/bolt/connection/query_api/impl/LogoffSummaryImpl.java
+++ b/neo4j-bolt-connection-query-api/src/main/java/org/neo4j/bolt/connection/query_api/impl/LogoffSummaryImpl.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.bolt.connection.query_api.impl;
+
+import org.neo4j.bolt.connection.summary.LogoffSummary;
+
+record LogoffSummaryImpl() implements LogoffSummary {
+    static final LogoffSummaryImpl INSTANCE = new LogoffSummaryImpl();
+}

--- a/neo4j-bolt-connection-query-api/src/main/java/org/neo4j/bolt/connection/query_api/impl/LogonMessageHandler.java
+++ b/neo4j-bolt-connection-query-api/src/main/java/org/neo4j/bolt/connection/query_api/impl/LogonMessageHandler.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.bolt.connection.query_api.impl;
+
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.function.Consumer;
+import org.neo4j.bolt.connection.AuthToken;
+import org.neo4j.bolt.connection.ResponseHandler;
+import org.neo4j.bolt.connection.message.LogonMessage;
+
+final class LogonMessageHandler implements MessageHandler<Void> {
+    private final ResponseHandler handler;
+    private final LogonMessage message;
+    private final Consumer<AuthToken> authTokenHandler;
+
+    LogonMessageHandler(ResponseHandler handler, LogonMessage message, Consumer<AuthToken> authTokenHandler) {
+        this.handler = Objects.requireNonNull(handler);
+        this.message = Objects.requireNonNull(message);
+        this.authTokenHandler = Objects.requireNonNull(authTokenHandler);
+    }
+
+    @Override
+    public CompletionStage<Void> exchange() {
+        return CompletableFuture.completedStage(null).thenApply(ignored -> {
+            authTokenHandler.accept(message.authToken());
+            handler.onLogonSummary(LogonSummaryImpl.INSTANCE);
+            return null;
+        });
+    }
+}

--- a/neo4j-bolt-connection-query-api/src/main/java/org/neo4j/bolt/connection/query_api/impl/LogonSummaryImpl.java
+++ b/neo4j-bolt-connection-query-api/src/main/java/org/neo4j/bolt/connection/query_api/impl/LogonSummaryImpl.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.bolt.connection.query_api.impl;
+
+import org.neo4j.bolt.connection.summary.LogonSummary;
+
+record LogonSummaryImpl() implements LogonSummary {
+    static final LogonSummaryImpl INSTANCE = new LogonSummaryImpl();
+}

--- a/neo4j-bolt-connection-query-api/src/main/java/org/neo4j/bolt/connection/query_api/impl/QueryApiBoltConnectionProvider.java
+++ b/neo4j-bolt-connection-query-api/src/main/java/org/neo4j/bolt/connection/query_api/impl/QueryApiBoltConnectionProvider.java
@@ -22,6 +22,7 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.time.Clock;
 import java.time.Duration;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
@@ -48,12 +49,14 @@ public class QueryApiBoltConnectionProvider implements BoltConnectionProvider {
     // Higher versions of Bolt require GQL support that it not available in Query API.
     private final BoltProtocolVersion BOLT_PROTOCOL_VERSION = new BoltProtocolVersion(5, 4);
     private final Executor httpExecutor;
+    private final Clock clock;
 
-    public QueryApiBoltConnectionProvider(LoggingProvider logging, ValueFactory valueFactory) {
+    public QueryApiBoltConnectionProvider(LoggingProvider logging, ValueFactory valueFactory, Clock clock) {
         this.logging = Objects.requireNonNull(logging);
         this.logger = logging.getLog(getClass());
         this.valueFactory = Objects.requireNonNull(valueFactory);
         this.httpExecutor = Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors());
+        this.clock = Objects.requireNonNull(clock);
     }
 
     @SuppressWarnings("resource") // not AutoCloseable in Java 17
@@ -114,6 +117,7 @@ public class QueryApiBoltConnectionProvider implements BoltConnectionProvider {
                                     userAgent,
                                     serverAgent,
                                     BOLT_PROTOCOL_VERSION,
+                                    clock,
                                     logging);
                         } catch (IOException e) {
                             throw new BoltClientException(

--- a/neo4j-bolt-connection-query-api/src/main/java/org/neo4j/bolt/connection/query_api/impl/RunMessageHandler.java
+++ b/neo4j-bolt-connection-query-api/src/main/java/org/neo4j/bolt/connection/query_api/impl/RunMessageHandler.java
@@ -43,6 +43,7 @@ final class RunMessageHandler extends AbstractMessageHandler<Query> {
     private final System.Logger log;
     private final ResponseHandler handler;
     private final HttpContext httpContext;
+    private final Supplier<String> authHeaderSupplier;
     private final HttpRequest.BodyPublisher bodyPublisher;
     private final ValueFactory valueFactory;
     private final RunMessage message;
@@ -53,6 +54,7 @@ final class RunMessageHandler extends AbstractMessageHandler<Query> {
     RunMessageHandler(
             ResponseHandler handler,
             HttpContext httpContext,
+            Supplier<String> authHeaderSupplier,
             ValueFactory valueFactory,
             RunMessage message,
             Supplier<TransactionInfo> transactionInfoSupplier,
@@ -61,6 +63,7 @@ final class RunMessageHandler extends AbstractMessageHandler<Query> {
         this.log = logging.getLog(getClass());
         this.handler = Objects.requireNonNull(handler);
         this.httpContext = Objects.requireNonNull(httpContext);
+        this.authHeaderSupplier = Objects.requireNonNull(authHeaderSupplier);
         this.valueFactory = Objects.requireNonNull(valueFactory);
         this.message = Objects.requireNonNull(message);
         this.transactionInfoSupplier = Objects.requireNonNull(transactionInfoSupplier);
@@ -80,7 +83,7 @@ final class RunMessageHandler extends AbstractMessageHandler<Query> {
         var transactionInfo = transactionInfoSupplier.get();
         String databaseName;
         URI uri;
-        var headers = httpContext.headers();
+        var headers = httpContext.headers(authHeaderSupplier.get());
         if (transactionInfo != null) {
             databaseName = transactionInfo.databaseName();
             uri = httpContext.txUrl(transactionInfo);

--- a/neo4j-bolt-connection-query-api/src/test/java/org/neo4j/bolt/connection/query_api/impl/HttpContextTest.java
+++ b/neo4j-bolt-connection-query-api/src/test/java/org/neo4j/bolt/connection/query_api/impl/HttpContextTest.java
@@ -40,15 +40,15 @@ class HttpContextTest {
             })
     void shouldNormalizeBase(URI uri) {
 
-        var httpContext = new HttpContext(HttpClient.newHttpClient(), uri, JSON.std, new String[] {}, null);
+        var httpContext = new HttpContext(HttpClient.newHttpClient(), uri, JSON.std, null);
         var expected = uri.toString() + (uri.toString().endsWith("/") ? "" : "/") + "db/foo/query/v2";
         Assertions.assertEquals(expected, httpContext.queryUrl("foo").toString());
     }
 
     @Test
     void txUrlShouldWork() {
-        var httpContext = new HttpContext(
-                HttpClient.newHttpClient(), URI.create("http://localhost:7474"), JSON.std, new String[] {}, null);
+        var httpContext =
+                new HttpContext(HttpClient.newHttpClient(), URI.create("http://localhost:7474"), JSON.std, null);
         Assertions.assertEquals(
                 "http://localhost:7474/db/ads/query/v2/tx",
                 httpContext.txUrl("ads").toString());
@@ -60,7 +60,6 @@ class HttpContextTest {
                 HttpClient.newHttpClient(),
                 URI.create("http://localhost:7474?defaultDatabase=neo4j&ignored=value"),
                 JSON.std,
-                new String[] {},
                 null);
 
         Assertions.assertEquals("neo4j", httpContext.defaultDatabase());

--- a/neo4j-bolt-connection-query-api/src/test/java/org/neo4j/bolt/connection/query_api/impl/QueryApiBoltConnectionTest.java
+++ b/neo4j-bolt-connection-query-api/src/test/java/org/neo4j/bolt/connection/query_api/impl/QueryApiBoltConnectionTest.java
@@ -31,6 +31,7 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpHeaders;
 import java.net.http.HttpResponse;
+import java.time.Clock;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -94,6 +95,7 @@ final class QueryApiBoltConnectionTest {
                 "userAgent",
                 "serverAgent",
                 new BoltProtocolVersion(5, 6),
+                Clock.systemUTC(),
                 loggingProvider);
     }
 


### PR DESCRIPTION
This update adds support for `LOGOFF` and `LOGON` messages providing that they are submitted strictly as a pair where `LOGOFF` message is immediately followed by `LOGON` message. 

The effect of handling these messages is an update of authentication details used for subsequent requests. As there is no endpoint for just verifying the new details, no network exchange happens when these details are updated. However, the updated details are expected to be verified by the server upon a subsequent authenticated exchange.
