### PR TITLE
feat(value): use Java List for Bolt List

### DIFF
--- a/neo4j-bolt-connection-bom/pom.xml
+++ b/neo4j-bolt-connection-bom/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.neo4j.bolt</groupId>
         <artifactId>neo4j-bolt-connection-parent</artifactId>
-        <version>4.1-SNAPSHOT</version>
+        <version>5.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>neo4j-bolt-connection-bom</artifactId>

--- a/neo4j-bolt-connection-netty/pom.xml
+++ b/neo4j-bolt-connection-netty/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.neo4j.bolt</groupId>
         <artifactId>neo4j-bolt-connection-parent</artifactId>
-        <version>4.1-SNAPSHOT</version>
+        <version>5.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>neo4j-bolt-connection-netty</artifactId>

--- a/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/BoltConnectionImpl.java
+++ b/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/BoltConnectionImpl.java
@@ -307,7 +307,7 @@ public final class BoltConnectionImpl implements BoltConnection {
                 pullMessage.request(),
                 new PullMessageHandler() {
                     @Override
-                    public void onRecord(Value[] fields) {
+                    public void onRecord(List<Value> fields) {
                         handler.onRecord(fields);
                     }
 
@@ -626,7 +626,7 @@ public final class BoltConnectionImpl implements BoltConnection {
         }
 
         @Override
-        public void onRecord(Value[] fields) {
+        public void onRecord(List<Value> fields) {
             if (!summariesFuture.isDone()) {
                 runIgnoringError(() -> delegate.onRecord(fields));
             }

--- a/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/async/inbound/InboundMessageDispatcher.java
+++ b/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/async/inbound/InboundMessageDispatcher.java
@@ -20,8 +20,8 @@ import static java.util.Objects.requireNonNull;
 import static org.neo4j.bolt.connection.netty.impl.async.connection.ChannelAttributes.isClosing;
 
 import io.netty.channel.Channel;
-import java.util.Arrays;
 import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
 import java.util.Queue;
 import org.neo4j.bolt.connection.GqlError;
@@ -85,14 +85,13 @@ public class InboundMessageDispatcher implements ResponseMessageHandler {
     }
 
     @Override
-    public void handleRecordMessage(Value[] fields) {
+    public void handleRecordMessage(List<Value> fields) {
         if (log.isLoggable(System.Logger.Level.DEBUG)) {
-            log.log(System.Logger.Level.DEBUG, "S: RECORD %s", Arrays.toString(fields));
+            log.log(System.Logger.Level.DEBUG, "S: RECORD %s", fields.toString());
         }
         var handler = handlers.peek();
         if (handler == null) {
-            throw new IllegalStateException(
-                    "No handler exists to handle RECORD message with fields: " + Arrays.toString(fields));
+            throw new IllegalStateException("No handler exists to handle RECORD message with fields: " + fields);
         }
         handler.onRecord(fields);
     }

--- a/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/handlers/BeginTxResponseHandler.java
+++ b/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/handlers/BeginTxResponseHandler.java
@@ -18,7 +18,7 @@ package org.neo4j.bolt.connection.netty.impl.handlers;
 
 import static java.util.Objects.requireNonNull;
 
-import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -46,9 +46,8 @@ public class BeginTxResponseHandler implements ResponseHandler {
     }
 
     @Override
-    public void onRecord(Value[] fields) {
-        throw new UnsupportedOperationException(
-                "Transaction begin is not expected to receive records: " + Arrays.toString(fields));
+    public void onRecord(List<Value> fields) {
+        throw new UnsupportedOperationException("Transaction begin is not expected to receive records: " + fields);
     }
 
     private record BeginSummaryImpl(String database) implements BeginSummary {

--- a/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/handlers/CommitTxResponseHandler.java
+++ b/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/handlers/CommitTxResponseHandler.java
@@ -18,7 +18,7 @@ package org.neo4j.bolt.connection.netty.impl.handlers;
 
 import static java.util.Objects.requireNonNull;
 
-import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import org.neo4j.bolt.connection.netty.impl.spi.ResponseHandler;
@@ -36,7 +36,7 @@ public class CommitTxResponseHandler implements ResponseHandler {
     public void onSuccess(Map<String, Value> metadata) {
         var bookmarkValue = metadata.get("bookmark");
         String bookmark = null;
-        if (bookmarkValue != null && !bookmarkValue.isNull() && Type.STRING.equals(bookmarkValue.type())) {
+        if (bookmarkValue != null && !bookmarkValue.isNull() && Type.STRING.equals(bookmarkValue.boltValueType())) {
             bookmark = bookmarkValue.asString();
             if (bookmark.isEmpty()) {
                 bookmark = null;
@@ -51,8 +51,7 @@ public class CommitTxResponseHandler implements ResponseHandler {
     }
 
     @Override
-    public void onRecord(Value[] fields) {
-        throw new UnsupportedOperationException(
-                "Transaction commit is not expected to receive records: " + Arrays.toString(fields));
+    public void onRecord(List<Value> fields) {
+        throw new UnsupportedOperationException("Transaction commit is not expected to receive records: " + fields);
     }
 }

--- a/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/handlers/DiscardResponseHandler.java
+++ b/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/handlers/DiscardResponseHandler.java
@@ -16,6 +16,7 @@
  */
 package org.neo4j.bolt.connection.netty.impl.handlers;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
@@ -41,7 +42,7 @@ public class DiscardResponseHandler implements ResponseHandler {
     }
 
     @Override
-    public void onRecord(Value[] fields) {}
+    public void onRecord(List<Value> fields) {}
 
     private record DiscardSummaryImpl(Map<String, Value> metadata) implements DiscardSummary {
         @Override

--- a/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/handlers/HelloResponseHandler.java
+++ b/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/handlers/HelloResponseHandler.java
@@ -28,6 +28,7 @@ import static org.neo4j.bolt.connection.netty.impl.util.MetadataExtractor.extrac
 
 import io.netty.channel.Channel;
 import java.time.Clock;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -94,7 +95,7 @@ public class HelloResponseHandler implements ResponseHandler {
     }
 
     @Override
-    public void onRecord(Value[] fields) {
+    public void onRecord(List<Value> fields) {
         throw new UnsupportedOperationException();
     }
 
@@ -111,7 +112,7 @@ public class HelloResponseHandler implements ResponseHandler {
         var configurationHints = metadata.get(CONFIGURATION_HINTS_KEY);
         if (configurationHints != null) {
             getFromSupplierOrEmptyOnException(() -> configurationHints
-                            .get(CONNECTION_RECEIVE_TIMEOUT_SECONDS_KEY)
+                            .getBoltValue(CONNECTION_RECEIVE_TIMEOUT_SECONDS_KEY)
                             .asLong())
                     .ifPresent(timeout -> setConnectionReadTimeout(channel, timeout));
         }

--- a/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/handlers/HelloV51ResponseHandler.java
+++ b/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/handlers/HelloV51ResponseHandler.java
@@ -25,6 +25,7 @@ import static org.neo4j.bolt.connection.netty.impl.async.connection.ChannelAttri
 import static org.neo4j.bolt.connection.netty.impl.util.MetadataExtractor.extractServer;
 
 import io.netty.channel.Channel;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -72,7 +73,7 @@ public class HelloV51ResponseHandler implements ResponseHandler {
     }
 
     @Override
-    public void onRecord(Value[] fields) {
+    public void onRecord(List<Value> fields) {
         throw new UnsupportedOperationException();
     }
 
@@ -80,18 +81,18 @@ public class HelloV51ResponseHandler implements ResponseHandler {
         var configurationHints = metadata.get(CONFIGURATION_HINTS_KEY);
         if (configurationHints != null) {
             getFromSupplierOrEmptyOnException(() -> configurationHints
-                            .get(CONNECTION_RECEIVE_TIMEOUT_SECONDS_KEY)
+                            .getBoltValue(CONNECTION_RECEIVE_TIMEOUT_SECONDS_KEY)
                             .asLong())
                     .ifPresent(timeout -> setConnectionReadTimeout(channel, timeout));
 
             getFromSupplierOrEmptyOnException(() -> {
-                        var value = configurationHints.get(TELEMETRY_ENABLED_KEY);
+                        var value = configurationHints.getBoltValue(TELEMETRY_ENABLED_KEY);
                         return !value.isNull() && value.asBoolean();
                     })
                     .ifPresent(telemetryEnabled -> setTelemetryEnabled(channel, telemetryEnabled));
 
             getFromSupplierOrEmptyOnException(() -> {
-                        var value = configurationHints.get(SSR_ENABLED_KEY);
+                        var value = configurationHints.getBoltValue(SSR_ENABLED_KEY);
                         return !value.isNull() && value.asBoolean();
                     })
                     .ifPresent(telemetryEnabled -> setSsrEnabled(channel, telemetryEnabled));

--- a/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/handlers/LogoffResponseHandler.java
+++ b/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/handlers/LogoffResponseHandler.java
@@ -18,6 +18,7 @@ package org.neo4j.bolt.connection.netty.impl.handlers;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import org.neo4j.bolt.connection.exception.BoltProtocolException;
@@ -42,7 +43,7 @@ public class LogoffResponseHandler implements ResponseHandler {
     }
 
     @Override
-    public void onRecord(Value[] fields) {
+    public void onRecord(List<Value> fields) {
         this.future.completeExceptionally(new BoltProtocolException("Records are not supported on LOGON"));
     }
 }

--- a/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/handlers/LogonResponseHandler.java
+++ b/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/handlers/LogonResponseHandler.java
@@ -21,6 +21,7 @@ import static org.neo4j.bolt.connection.netty.impl.async.connection.ChannelAttri
 
 import io.netty.channel.Channel;
 import java.time.Clock;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import org.neo4j.bolt.connection.exception.BoltProtocolException;
@@ -58,7 +59,7 @@ public class LogonResponseHandler implements ResponseHandler {
     }
 
     @Override
-    public void onRecord(Value[] fields) {
+    public void onRecord(List<Value> fields) {
         future.completeExceptionally(new BoltProtocolException("Records are not supported on LOGON"));
     }
 }

--- a/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/handlers/NoOpResponseHandler.java
+++ b/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/handlers/NoOpResponseHandler.java
@@ -16,6 +16,7 @@
  */
 package org.neo4j.bolt.connection.netty.impl.handlers;
 
+import java.util.List;
 import java.util.Map;
 import org.neo4j.bolt.connection.netty.impl.spi.ResponseHandler;
 import org.neo4j.bolt.connection.values.Value;
@@ -30,5 +31,5 @@ public class NoOpResponseHandler implements ResponseHandler {
     public void onFailure(Throwable error) {}
 
     @Override
-    public void onRecord(Value[] fields) {}
+    public void onRecord(List<Value> fields) {}
 }

--- a/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/handlers/PullResponseHandlerImpl.java
+++ b/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/handlers/PullResponseHandlerImpl.java
@@ -16,6 +16,7 @@
  */
 package org.neo4j.bolt.connection.netty.impl.handlers;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import org.neo4j.bolt.connection.netty.impl.messaging.PullMessageHandler;
@@ -46,7 +47,7 @@ public class PullResponseHandlerImpl implements ResponseHandler {
     }
 
     @Override
-    public void onRecord(Value[] fields) {
+    public void onRecord(List<Value> fields) {
         handler.onRecord(fields);
     }
 

--- a/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/handlers/ResetResponseHandler.java
+++ b/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/handlers/ResetResponseHandler.java
@@ -16,6 +16,7 @@
  */
 package org.neo4j.bolt.connection.netty.impl.handlers;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -48,7 +49,7 @@ public class ResetResponseHandler implements ResponseHandler {
     }
 
     @Override
-    public final void onRecord(Value[] fields) {
+    public final void onRecord(List<Value> fields) {
         throw new UnsupportedOperationException();
     }
 

--- a/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/handlers/RollbackTxResponseHandler.java
+++ b/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/handlers/RollbackTxResponseHandler.java
@@ -18,7 +18,7 @@ package org.neo4j.bolt.connection.netty.impl.handlers;
 
 import static java.util.Objects.requireNonNull;
 
-import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import org.neo4j.bolt.connection.netty.impl.spi.ResponseHandler;
@@ -42,8 +42,7 @@ public class RollbackTxResponseHandler implements ResponseHandler {
     }
 
     @Override
-    public void onRecord(Value[] fields) {
-        throw new UnsupportedOperationException(
-                "Transaction rollback is not expected to receive records: " + Arrays.toString(fields));
+    public void onRecord(List<Value> fields) {
+        throw new UnsupportedOperationException("Transaction rollback is not expected to receive records: " + fields);
     }
 }

--- a/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/handlers/RouteMessageResponseHandler.java
+++ b/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/handlers/RouteMessageResponseHandler.java
@@ -18,7 +18,7 @@ package org.neo4j.bolt.connection.netty.impl.handlers;
 
 import static java.util.Objects.requireNonNull;
 
-import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
@@ -32,18 +32,16 @@ import org.neo4j.bolt.connection.values.ValueFactory;
  */
 public class RouteMessageResponseHandler implements ResponseHandler {
     private final CompletableFuture<Map<String, Value>> completableFuture;
-    private final ValueFactory valueFactory;
 
     public RouteMessageResponseHandler(
             final CompletableFuture<Map<String, Value>> completableFuture, ValueFactory valueFactory) {
         this.completableFuture = requireNonNull(completableFuture);
-        this.valueFactory = requireNonNull(valueFactory);
     }
 
     @Override
     public void onSuccess(Map<String, Value> metadata) {
         try {
-            completableFuture.complete(metadata.get("rt").asMap(valueFactory::value));
+            completableFuture.complete(metadata.get("rt").asBoltMap());
         } catch (Exception ex) {
             completableFuture.completeExceptionally(ex);
         }
@@ -55,9 +53,9 @@ public class RouteMessageResponseHandler implements ResponseHandler {
     }
 
     @Override
-    public void onRecord(Value[] fields) {
-        completableFuture.completeExceptionally(new UnsupportedOperationException(
-                "Route is not expected to receive records: " + Arrays.toString(fields)));
+    public void onRecord(List<Value> fields) {
+        completableFuture.completeExceptionally(
+                new UnsupportedOperationException("Route is not expected to receive records: " + fields));
     }
 
     @Override

--- a/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/handlers/RunResponseHandler.java
+++ b/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/handlers/RunResponseHandler.java
@@ -51,7 +51,7 @@ public class RunResponseHandler implements ResponseHandler {
     }
 
     @Override
-    public void onRecord(Value[] fields) {
+    public void onRecord(List<Value> fields) {
         throw new UnsupportedOperationException();
     }
 

--- a/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/handlers/TelemetryResponseHandler.java
+++ b/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/handlers/TelemetryResponseHandler.java
@@ -18,7 +18,7 @@ package org.neo4j.bolt.connection.netty.impl.handlers;
 
 import static java.util.Objects.requireNonNull;
 
-import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import org.neo4j.bolt.connection.netty.impl.messaging.request.TelemetryMessage;
@@ -52,8 +52,7 @@ public class TelemetryResponseHandler implements ResponseHandler {
     }
 
     @Override
-    public void onRecord(Value[] fields) {
-        throw new UnsupportedOperationException(
-                "Telemetry is not expected to receive records: " + Arrays.toString(fields));
+    public void onRecord(List<Value> fields) {
+        throw new UnsupportedOperationException("Telemetry is not expected to receive records: " + fields);
     }
 }

--- a/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/messaging/PullMessageHandler.java
+++ b/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/messaging/PullMessageHandler.java
@@ -16,9 +16,10 @@
  */
 package org.neo4j.bolt.connection.netty.impl.messaging;
 
+import java.util.List;
 import org.neo4j.bolt.connection.summary.PullSummary;
 import org.neo4j.bolt.connection.values.Value;
 
 public interface PullMessageHandler extends MessageHandler<PullSummary> {
-    void onRecord(Value[] fields);
+    void onRecord(List<Value> fields);
 }

--- a/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/messaging/ResponseMessageHandler.java
+++ b/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/messaging/ResponseMessageHandler.java
@@ -16,6 +16,7 @@
  */
 package org.neo4j.bolt.connection.netty.impl.messaging;
 
+import java.util.List;
 import java.util.Map;
 import org.neo4j.bolt.connection.GqlError;
 import org.neo4j.bolt.connection.values.Value;
@@ -23,7 +24,7 @@ import org.neo4j.bolt.connection.values.Value;
 public interface ResponseMessageHandler {
     void handleSuccessMessage(Map<String, Value> meta);
 
-    void handleRecordMessage(Value[] fields);
+    void handleRecordMessage(List<Value> fields);
 
     void handleFailureMessage(GqlError gqlError);
 

--- a/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/messaging/ValueUnpacker.java
+++ b/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/messaging/ValueUnpacker.java
@@ -17,6 +17,7 @@
 package org.neo4j.bolt.connection.netty.impl.messaging;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 import org.neo4j.bolt.connection.values.Value;
 
@@ -28,5 +29,5 @@ public interface ValueUnpacker {
 
     Map<String, Value> unpackMap() throws IOException;
 
-    Value[] unpackArray() throws IOException;
+    List<Value> unpackList() throws IOException;
 }

--- a/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/messaging/common/CommonMessageReader.java
+++ b/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/messaging/common/CommonMessageReader.java
@@ -85,7 +85,7 @@ public class CommonMessageReader implements MessageFormat.Reader {
     }
 
     private void unpackRecordMessage(ResponseMessageHandler output) throws IOException {
-        var fields = unpacker.unpackArray();
+        var fields = unpacker.unpackList();
         output.handleRecordMessage(fields);
     }
 }

--- a/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/messaging/common/CommonValuePacker.java
+++ b/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/messaging/common/CommonValuePacker.java
@@ -82,7 +82,11 @@ public class CommonValuePacker implements ValuePacker {
 
     @Override
     public final void pack(Value value) throws IOException {
-        packInternalValue(value);
+        if (value != null) {
+            packInternalValue(value);
+        } else {
+            throw new IllegalArgumentException("Unable to pack: null");
+        }
     }
 
     @Override
@@ -99,7 +103,7 @@ public class CommonValuePacker implements ValuePacker {
     }
 
     protected void packInternalValue(Value value) throws IOException {
-        switch (value.type()) {
+        switch (value.boltValueType()) {
             case DATE -> packDate(value.asLocalDate());
             case TIME -> packTime(value.asOffsetTime());
             case LOCAL_TIME -> packLocalTime(value.asLocalTime());
@@ -111,8 +115,8 @@ public class CommonValuePacker implements ValuePacker {
                     packZonedDateTime(value.asZonedDateTime());
                 }
             }
-            case DURATION -> packDuration(value.asIsoDuration());
-            case POINT -> packPoint(value.asPoint());
+            case DURATION -> packDuration(value.asBoltIsoDuration());
+            case POINT -> packPoint(value.asBoltPoint());
             case NULL -> packer.packNull();
             case BYTES -> packer.pack(value.asByteArray());
             case STRING -> packer.pack(value.asString());
@@ -123,16 +127,17 @@ public class CommonValuePacker implements ValuePacker {
                 packer.packMapHeader(value.size());
                 for (var s : value.keys()) {
                     packer.pack(s);
-                    pack(value.get(s));
+                    pack(value.getBoltValue(s));
                 }
             }
             case LIST -> {
                 packer.packListHeader(value.size());
-                for (var item : value.values()) {
+                for (var item : value.boltValues()) {
                     pack(item);
                 }
             }
-            default -> throw new IOException("Unknown type: " + value.type().name());
+            default -> throw new IOException(
+                    "Unknown type: " + value.boltValueType().name());
         }
     }
 

--- a/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/messaging/common/CommonValueUnpacker.java
+++ b/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/messaging/common/CommonValueUnpacker.java
@@ -120,13 +120,13 @@ public class CommonValueUnpacker implements ValueUnpacker {
     }
 
     @Override
-    public Value[] unpackArray() throws IOException {
+    public List<Value> unpackList() throws IOException {
         var size = (int) unpacker.unpackListHeader();
         var values = new Value[size];
         for (var i = 0; i < size; i++) {
             values[i] = unpack();
         }
-        return values;
+        return Arrays.asList(values);
     }
 
     protected Value unpack() throws IOException {
@@ -154,12 +154,7 @@ public class CommonValueUnpacker implements ValueUnpacker {
                 return valueFactory.value(unpackMap());
             }
             case LIST -> {
-                var size = (int) unpacker.unpackListHeader();
-                var vals = new Value[size];
-                for (var j = 0; j < size; j++) {
-                    vals[j] = unpack();
-                }
-                return valueFactory.value(vals);
+                return valueFactory.value(unpackList());
             }
             case STRUCT -> {
                 var size = unpacker.unpackStructHeader();

--- a/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/messaging/response/RecordMessage.java
+++ b/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/messaging/response/RecordMessage.java
@@ -16,11 +16,11 @@
  */
 package org.neo4j.bolt.connection.netty.impl.messaging.response;
 
-import java.util.Arrays;
+import java.util.List;
 import org.neo4j.bolt.connection.netty.impl.messaging.Message;
 import org.neo4j.bolt.connection.values.Value;
 
-public record RecordMessage(Value[] fields) implements Message {
+public record RecordMessage(List<Value> fields) implements Message {
     public static final byte SIGNATURE = 0x71;
 
     @Override
@@ -30,7 +30,7 @@ public record RecordMessage(Value[] fields) implements Message {
 
     @Override
     public String toString() {
-        return "RECORD " + Arrays.toString(fields);
+        return "RECORD " + fields;
     }
 
     @Override
@@ -44,11 +44,11 @@ public record RecordMessage(Value[] fields) implements Message {
 
         var that = (RecordMessage) o;
 
-        return Arrays.equals(fields, that.fields);
+        return fields.equals(that.fields);
     }
 
     @Override
     public int hashCode() {
-        return Arrays.hashCode(fields);
+        return fields.hashCode();
     }
 }

--- a/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/messaging/v3/BoltProtocolV3.java
+++ b/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/messaging/v3/BoltProtocolV3.java
@@ -26,6 +26,7 @@ import java.time.Duration;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -176,9 +177,9 @@ public class BoltProtocolV3 implements BoltProtocol {
                     Set<BoltServerAddress> writers = new LinkedHashSet<>();
                     Set<BoltServerAddress> routers = new LinkedHashSet<>();
 
-                    for (var serversMap : map.get("servers").values()) {
-                        var role = serversMap.get("role").asString();
-                        for (var server : serversMap.get("addresses").values()) {
+                    for (var serversMap : map.get("servers").boltValues()) {
+                        var role = serversMap.getBoltValue("role").asString();
+                        for (var server : serversMap.getBoltValue("addresses").boltValues()) {
                             var address = new BoltServerAddress(server.asString());
                             switch (role) {
                                 case "WRITE" -> writers.add(address);
@@ -212,12 +213,12 @@ public class BoltProtocolV3 implements BoltProtocol {
                         private Map<String, Value> routingTable;
 
                         @Override
-                        public void onRecord(Value[] fields) {
+                        public void onRecord(List<Value> fields) {
                             if (routingTable == null) {
                                 var keys = runFuture.join().keys();
                                 routingTable = new HashMap<>(keys.size());
                                 for (var i = 0; i < keys.size(); i++) {
-                                    routingTable.put(keys.get(i), fields[i]);
+                                    routingTable.put(keys.get(i), fields.get(i));
                                 }
                                 routingTable = Collections.unmodifiableMap(routingTable);
                             }

--- a/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/messaging/v4/BoltProtocolV4.java
+++ b/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/messaging/v4/BoltProtocolV4.java
@@ -20,6 +20,7 @@ import java.time.Clock;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -110,9 +111,9 @@ public class BoltProtocolV4 extends BoltProtocolV3 {
                     Set<BoltServerAddress> writers = new LinkedHashSet<>();
                     Set<BoltServerAddress> routers = new LinkedHashSet<>();
 
-                    for (var serversMap : map.get("servers").values()) {
-                        var role = serversMap.get("role").asString();
-                        for (var server : serversMap.get("addresses").values()) {
+                    for (var serversMap : map.get("servers").boltValues()) {
+                        var role = serversMap.getBoltValue("role").asString();
+                        for (var server : serversMap.getBoltValue("addresses").boltValues()) {
                             var address = new BoltServerAddress(server.asString());
                             switch (role) {
                                 case "WRITE" -> writers.add(address);
@@ -146,12 +147,12 @@ public class BoltProtocolV4 extends BoltProtocolV3 {
                         private Map<String, Value> routingTable;
 
                         @Override
-                        public void onRecord(Value[] fields) {
+                        public void onRecord(List<Value> fields) {
                             if (routingTable == null) {
                                 var keys = runFuture.join().keys();
                                 routingTable = new HashMap<>(keys.size());
                                 for (var i = 0; i < keys.size(); i++) {
-                                    routingTable.put(keys.get(i), fields[i]);
+                                    routingTable.put(keys.get(i), fields.get(i));
                                 }
                                 routingTable = Collections.unmodifiableMap(routingTable);
                             }

--- a/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/messaging/v43/BoltProtocolV43.java
+++ b/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/messaging/v43/BoltProtocolV43.java
@@ -77,9 +77,9 @@ public class BoltProtocolV43 extends BoltProtocolV42 {
                     Set<BoltServerAddress> writers = new LinkedHashSet<>();
                     Set<BoltServerAddress> routers = new LinkedHashSet<>();
 
-                    for (var serversMap : map.get("servers").values()) {
-                        var role = serversMap.get("role").asString();
-                        for (var server : serversMap.get("addresses").values()) {
+                    for (var serversMap : map.get("servers").boltValues()) {
+                        var role = serversMap.getBoltValue("role").asString();
+                        for (var server : serversMap.getBoltValue("addresses").boltValues()) {
                             var address = new BoltServerAddress(server.asString());
                             switch (role) {
                                 case "WRITE" -> writers.add(address);

--- a/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/messaging/v57/MessageReaderV57.java
+++ b/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/messaging/v57/MessageReaderV57.java
@@ -48,14 +48,14 @@ public class MessageReaderV57 extends MessageReaderV5 {
         var message = params.get("message").asString();
         Map<String, Value> diagnosticRecord;
         var diagnosticRecordValue = params.get("diagnostic_record");
-        if (diagnosticRecordValue != null && Type.MAP.equals(diagnosticRecordValue.type())) {
+        if (diagnosticRecordValue != null && Type.MAP.equals(diagnosticRecordValue.boltValueType())) {
             var containsOperation = diagnosticRecordValue.containsKey("OPERATION");
             var containsOperationCode = diagnosticRecordValue.containsKey("OPERATION_CODE");
             var containsCurrentSchema = diagnosticRecordValue.containsKey("CURRENT_SCHEMA");
             if (containsOperation && containsOperationCode && containsCurrentSchema) {
-                diagnosticRecord = diagnosticRecordValue.asMap(valueFactory::value);
+                diagnosticRecord = diagnosticRecordValue.asBoltMap();
             } else {
-                diagnosticRecord = new HashMap<>(diagnosticRecordValue.asMap(valueFactory::value));
+                diagnosticRecord = new HashMap<>(diagnosticRecordValue.asBoltMap());
                 if (!containsOperation) {
                     diagnosticRecord.put("OPERATION", valueFactory.value(""));
                 }
@@ -77,10 +77,10 @@ public class MessageReaderV57 extends MessageReaderV5 {
         GqlError gqlError = null;
         var cause = params.get("cause");
         if (cause != null) {
-            if (!Type.MAP.equals(cause.type())) {
+            if (!Type.MAP.equals(cause.boltValueType())) {
                 throw new BoltProtocolException("Unexpected type");
             }
-            gqlError = unpackGqlError(cause.asMap(valueFactory::value));
+            gqlError = unpackGqlError(cause.asBoltMap());
         }
 
         return new GqlError(gqlStatus, statusDescription, code, message, diagnosticRecord, gqlError);

--- a/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/spi/ResponseHandler.java
+++ b/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/spi/ResponseHandler.java
@@ -16,6 +16,7 @@
  */
 package org.neo4j.bolt.connection.netty.impl.spi;
 
+import java.util.List;
 import java.util.Map;
 import org.neo4j.bolt.connection.netty.impl.async.inbound.InboundMessageDispatcher;
 import org.neo4j.bolt.connection.values.Value;
@@ -25,7 +26,7 @@ public interface ResponseHandler {
 
     void onFailure(Throwable error);
 
-    void onRecord(Value[] fields);
+    void onRecord(List<Value> fields);
 
     /**
      * Tells whether this response handler is able to manage auto-read of the underlying connection using {@link Connection#enableAutoRead()} and

--- a/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/util/MetadataExtractor.java
+++ b/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/util/MetadataExtractor.java
@@ -39,7 +39,7 @@ public class MetadataExtractor {
         if (keysValue != null) {
             if (!keysValue.isEmpty()) {
                 List<String> keys = new ArrayList<>(keysValue.size());
-                for (var value : keysValue.values()) {
+                for (var value : keysValue.boltValues()) {
                     keys.add(value.asString());
                 }
 
@@ -81,7 +81,7 @@ public class MetadataExtractor {
     public static Set<String> extractBoltPatches(Map<String, Value> metadata) {
         var boltPatch = metadata.get("patch_bolt");
         if (boltPatch != null && !boltPatch.isNull()) {
-            return StreamSupport.stream(boltPatch.values().spliterator(), false)
+            return StreamSupport.stream(boltPatch.boltValues().spliterator(), false)
                     .map(Value::asString)
                     .collect(Collectors.toSet());
         } else {

--- a/neo4j-bolt-connection-netty/src/test/java/org/neo4j/bolt/connection/netty/impl/async/inbound/InboundMessageDispatcherTest.java
+++ b/neo4j-bolt-connection-netty/src/test/java/org/neo4j/bolt/connection/netty/impl/async/inbound/InboundMessageDispatcherTest.java
@@ -39,6 +39,7 @@ import io.netty.channel.DefaultChannelId;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.util.Attribute;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.ResourceBundle;
 import org.junit.jupiter.api.Test;
@@ -118,9 +119,9 @@ class InboundMessageDispatcherTest {
         dispatcher.enqueue(handler);
         assertEquals(1, dispatcher.queuedHandlersCount());
 
-        var fields1 = new Value[] {valueFactory.value(1)};
-        var fields2 = new Value[] {valueFactory.value(2)};
-        var fields3 = new Value[] {valueFactory.value(3)};
+        var fields1 = List.of(valueFactory.value(1));
+        var fields2 = List.of(valueFactory.value(2));
+        var fields3 = List.of(valueFactory.value(3));
 
         dispatcher.handleRecordMessage(fields1);
         dispatcher.handleRecordMessage(fields2);
@@ -182,7 +183,7 @@ class InboundMessageDispatcherTest {
 
         assertThrows(
                 IllegalStateException.class,
-                () -> dispatcher.handleRecordMessage(new Value[] {valueFactory.value(1), valueFactory.value(2)}));
+                () -> dispatcher.handleRecordMessage(List.of(valueFactory.value(1), valueFactory.value(2))));
     }
 
     @Test
@@ -294,7 +295,7 @@ class InboundMessageDispatcherTest {
                                 anyString());
             };
         } else if (RecordMessage.class.isAssignableFrom(message)) {
-            dispatcher.handleRecordMessage(new Value[0]);
+            dispatcher.handleRecordMessage(List.of());
             loggerVerification = () -> {
                 verify(logger).isLoggable(System.Logger.Level.DEBUG);
                 verify(logger).log(eq(System.Logger.Level.DEBUG), eq((ResourceBundle) null), anyString(), anyString());

--- a/neo4j-bolt-connection-netty/src/test/java/org/neo4j/bolt/connection/netty/impl/async/inbound/InboundMessageHandlerTest.java
+++ b/neo4j-bolt-connection-netty/src/test/java/org/neo4j/bolt/connection/netty/impl/async/inbound/InboundMessageHandlerTest.java
@@ -30,6 +30,7 @@ import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.DecoderException;
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -106,7 +107,7 @@ class InboundMessageHandlerTest {
         var responseHandler = mock(ResponseHandler.class);
         messageDispatcher.enqueue(responseHandler);
 
-        var fields = new Value[] {valueFactory.value(1), valueFactory.value(2), valueFactory.value(3)};
+        var fields = List.of(valueFactory.value(1), valueFactory.value(2), valueFactory.value(3));
         channel.writeInbound(writer.asByteBuf(new RecordMessage(fields)));
 
         verify(responseHandler).onRecord(fields);

--- a/neo4j-bolt-connection-netty/src/test/java/org/neo4j/bolt/connection/netty/impl/handlers/CommitTxResponseHandlerTest.java
+++ b/neo4j-bolt-connection-netty/src/test/java/org/neo4j/bolt/connection/netty/impl/handlers/CommitTxResponseHandlerTest.java
@@ -23,10 +23,10 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.neo4j.bolt.connection.netty.impl.util.TestUtil.await;
 
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import org.junit.jupiter.api.Test;
 import org.neo4j.bolt.connection.test.values.TestValueFactory;
-import org.neo4j.bolt.connection.values.Value;
 import org.neo4j.bolt.connection.values.ValueFactory;
 
 class CommitTxResponseHandlerTest {
@@ -62,6 +62,6 @@ class CommitTxResponseHandlerTest {
 
     @Test
     void shouldFailToHandleRecord() {
-        assertThrows(UnsupportedOperationException.class, () -> handler.onRecord(new Value[] {valueFactory.value(42)}));
+        assertThrows(UnsupportedOperationException.class, () -> handler.onRecord(List.of(valueFactory.value(42))));
     }
 }

--- a/neo4j-bolt-connection-netty/src/test/java/org/neo4j/bolt/connection/netty/impl/handlers/ResetResponseHandlerTest.java
+++ b/neo4j-bolt-connection-netty/src/test/java/org/neo4j/bolt/connection/netty/impl/handlers/ResetResponseHandlerTest.java
@@ -22,10 +22,10 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import org.junit.jupiter.api.Test;
 import org.neo4j.bolt.connection.test.values.TestValueFactory;
-import org.neo4j.bolt.connection.values.Value;
 import org.neo4j.bolt.connection.values.ValueFactory;
 
 class ResetResponseHandlerTest {
@@ -62,8 +62,7 @@ class ResetResponseHandlerTest {
 
         assertThrows(
                 UnsupportedOperationException.class,
-                () -> handler.onRecord(
-                        new Value[] {valueFactory.value(1), valueFactory.value(2), valueFactory.value(3)}));
+                () -> handler.onRecord(List.of(valueFactory.value(1), valueFactory.value(2), valueFactory.value(3))));
     }
 
     private static ResetResponseHandler newHandler(CompletableFuture<Void> future) {

--- a/neo4j-bolt-connection-netty/src/test/java/org/neo4j/bolt/connection/netty/impl/handlers/RouteMessageResponseHandlerTest.java
+++ b/neo4j-bolt-connection-netty/src/test/java/org/neo4j/bolt/connection/netty/impl/handlers/RouteMessageResponseHandlerTest.java
@@ -23,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
@@ -78,7 +79,7 @@ class RouteMessageResponseHandlerTest {
         var completableFuture = new CompletableFuture<Map<String, Value>>();
         var responseHandler = new RouteMessageResponseHandler(completableFuture, valueFactory);
 
-        responseHandler.onRecord(new Value[0]);
+        responseHandler.onRecord(List.of());
 
         assertTrue(completableFuture.isCompletedExceptionally());
         completableFuture.handle((value, ex) -> {

--- a/neo4j-bolt-connection-netty/src/test/java/org/neo4j/bolt/connection/netty/impl/handlers/RunResponseHandlerTest.java
+++ b/neo4j-bolt-connection-netty/src/test/java/org/neo4j/bolt/connection/netty/impl/handlers/RunResponseHandlerTest.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import org.junit.jupiter.api.Test;
@@ -29,7 +30,6 @@ import org.neo4j.bolt.connection.netty.impl.messaging.v3.BoltProtocolV3;
 import org.neo4j.bolt.connection.netty.impl.util.MetadataExtractor;
 import org.neo4j.bolt.connection.summary.RunSummary;
 import org.neo4j.bolt.connection.test.values.TestValueFactory;
-import org.neo4j.bolt.connection.values.Value;
 import org.neo4j.bolt.connection.values.ValueFactory;
 
 class RunResponseHandlerTest {
@@ -67,7 +67,7 @@ class RunResponseHandlerTest {
         assertThrows(
                 UnsupportedOperationException.class,
                 () -> handler.onRecord(
-                        new Value[] {valueFactory.value("a"), valueFactory.value("b"), valueFactory.value("c")}));
+                        List.of(valueFactory.value("a"), valueFactory.value("b"), valueFactory.value("c"))));
     }
 
     private static RunResponseHandler newHandler() {

--- a/neo4j-bolt-connection-netty/src/test/java/org/neo4j/bolt/connection/netty/impl/messaging/MessageFormatTest.java
+++ b/neo4j-bolt-connection-netty/src/test/java/org/neo4j/bolt/connection/netty/impl/messaging/MessageFormatTest.java
@@ -28,6 +28,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
@@ -58,7 +59,7 @@ class MessageFormatTest {
     void shouldUnpackAllResponses() {
         assertSerializes(new FailureMessage("Hello", "World!"));
         assertSerializes(IgnoredMessage.IGNORED);
-        assertSerializes(new RecordMessage(new Value[] {valueFactory.value(1337L)}));
+        assertSerializes(new RecordMessage(List.of(valueFactory.value(1337L))));
         assertSerializes(new SuccessMessage(new HashMap<>()));
     }
 
@@ -114,7 +115,7 @@ class MessageFormatTest {
             }
 
             @Override
-            public void onRecord(Value[] fields) {
+            public void onRecord(List<Value> fields) {
                 // ignored
             }
         });
@@ -130,7 +131,7 @@ class MessageFormatTest {
     }
 
     private void assertSerializesValue(Value value) {
-        assertSerializes(new RecordMessage(new Value[] {value}));
+        assertSerializes(new RecordMessage(List.of(value)));
     }
 
     private void assertSerializes(Message message) {
@@ -175,7 +176,7 @@ class MessageFormatTest {
     }
 
     private void assertOnlyDeserializesValue(Value value) {
-        var message = new RecordMessage(new Value[] {value});
+        var message = new RecordMessage(List.of(value));
         var packed = knowledgeablePack(message);
 
         var channel = newEmbeddedChannel();

--- a/neo4j-bolt-connection-netty/src/test/java/org/neo4j/bolt/connection/netty/impl/messaging/response/RecordMessageTest.java
+++ b/neo4j-bolt-connection-netty/src/test/java/org/neo4j/bolt/connection/netty/impl/messaging/response/RecordMessageTest.java
@@ -19,12 +19,12 @@ package org.neo4j.bolt.connection.netty.impl.messaging.response;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.stream.Stream;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.neo4j.bolt.connection.test.values.TestValueFactory;
-import org.neo4j.bolt.connection.values.Value;
 import org.neo4j.bolt.connection.values.ValueFactory;
 
 class RecordMessageTest {
@@ -37,14 +37,11 @@ class RecordMessageTest {
     }
 
     static Stream<Arguments> equalsArgs() {
-        var message = new RecordMessage(new Value[] {valueFactory.value(1), valueFactory.value("1")});
+        var message = new RecordMessage(List.of(valueFactory.value(1), valueFactory.value("1")));
         return Stream.of(
+                Arguments.of(message, new RecordMessage(List.of(valueFactory.value(1), valueFactory.value("1"))), true),
                 Arguments.of(
-                        message, new RecordMessage(new Value[] {valueFactory.value(1), valueFactory.value("1")}), true),
-                Arguments.of(
-                        message,
-                        new RecordMessage(new Value[] {valueFactory.value(2), valueFactory.value("2")}),
-                        false),
+                        message, new RecordMessage(List.of(valueFactory.value(2), valueFactory.value("2"))), false),
                 Arguments.of(message, new SuccessMessage(Collections.emptyMap()), false),
                 Arguments.of(message, message, true),
                 Arguments.of(message, null, false));

--- a/neo4j-bolt-connection-netty/src/test/java/org/neo4j/bolt/connection/netty/impl/messaging/v3/BoltProtocolV3Test.java
+++ b/neo4j-bolt-connection-netty/src/test/java/org/neo4j/bolt/connection/netty/impl/messaging/v3/BoltProtocolV3Test.java
@@ -196,25 +196,24 @@ public class BoltProtocolV3Test {
                 })
                 .willAnswer((Answer<CompletionStage<Void>>) invocation -> {
                     var handler = (PullResponseHandlerImpl) invocation.getArgument(1);
-                    handler.onRecord(new Value[] {
-                        value(1000),
-                        value(List.of(
-                                value(Map.of(
-                                        "role",
-                                        value("ROUTE"),
-                                        "addresses",
-                                        value(List.of(value("192.168.0.1:7867"))))),
-                                value(Map.of(
-                                        "role",
-                                        value("WRITE"),
-                                        "addresses",
-                                        value(List.of(value("192.168.0.1:7867"))))),
-                                value(Map.of(
-                                        "role",
-                                        value("READ"),
-                                        "addresses",
-                                        value(List.of(value("192.168.0.1:7867")))))))
-                    });
+                    handler.onRecord(List.of(
+                            value(1000),
+                            value(List.of(
+                                    value(Map.of(
+                                            "role",
+                                            value("ROUTE"),
+                                            "addresses",
+                                            value(List.of(value("192.168.0.1:7867"))))),
+                                    value(Map.of(
+                                            "role",
+                                            value("WRITE"),
+                                            "addresses",
+                                            value(List.of(value("192.168.0.1:7867"))))),
+                                    value(Map.of(
+                                            "role",
+                                            value("READ"),
+                                            "addresses",
+                                            value(List.of(value("192.168.0.1:7867")))))))));
                     handler.onSuccess(emptyMap());
                     return CompletableFuture.completedStage(null);
                 });

--- a/neo4j-bolt-connection-netty/src/test/java/org/neo4j/bolt/connection/netty/impl/messaging/v3/MessageReaderV3Test.java
+++ b/neo4j-bolt-connection-netty/src/test/java/org/neo4j/bolt/connection/netty/impl/messaging/v3/MessageReaderV3Test.java
@@ -100,6 +100,6 @@ public class MessageReaderV3Test extends AbstractMessageReaderTestBase {
     }
 
     private Message record(Value value) {
-        return new RecordMessage(new Value[] {value});
+        return new RecordMessage(List.of(value));
     }
 }

--- a/neo4j-bolt-connection-netty/src/test/java/org/neo4j/bolt/connection/netty/impl/messaging/v4/BoltProtocolV4Test.java
+++ b/neo4j-bolt-connection-netty/src/test/java/org/neo4j/bolt/connection/netty/impl/messaging/v4/BoltProtocolV4Test.java
@@ -183,25 +183,24 @@ public final class BoltProtocolV4Test {
                 })
                 .willAnswer((Answer<CompletionStage<Void>>) invocation -> {
                     var handler = (PullResponseHandlerImpl) invocation.getArgument(1);
-                    handler.onRecord(new Value[] {
-                        value(1000),
-                        value(List.of(
-                                value(Map.of(
-                                        "role",
-                                        value("ROUTE"),
-                                        "addresses",
-                                        value(List.of(value("192.168.0.1:7867"))))),
-                                value(Map.of(
-                                        "role",
-                                        value("WRITE"),
-                                        "addresses",
-                                        value(List.of(value("192.168.0.1:7867"))))),
-                                value(Map.of(
-                                        "role",
-                                        value("READ"),
-                                        "addresses",
-                                        value(List.of(value("192.168.0.1:7867")))))))
-                    });
+                    handler.onRecord(List.of(
+                            value(1000),
+                            value(List.of(
+                                    value(Map.of(
+                                            "role",
+                                            value("ROUTE"),
+                                            "addresses",
+                                            value(List.of(value("192.168.0.1:7867"))))),
+                                    value(Map.of(
+                                            "role",
+                                            value("WRITE"),
+                                            "addresses",
+                                            value(List.of(value("192.168.0.1:7867"))))),
+                                    value(Map.of(
+                                            "role",
+                                            value("READ"),
+                                            "addresses",
+                                            value(List.of(value("192.168.0.1:7867")))))))));
                     handler.onSuccess(emptyMap());
                     return CompletableFuture.completedStage(null);
                 });

--- a/neo4j-bolt-connection-netty/src/test/java/org/neo4j/bolt/connection/netty/impl/messaging/v4/MessageReaderV4Test.java
+++ b/neo4j-bolt-connection-netty/src/test/java/org/neo4j/bolt/connection/netty/impl/messaging/v4/MessageReaderV4Test.java
@@ -100,6 +100,6 @@ public class MessageReaderV4Test extends AbstractMessageReaderTestBase {
     }
 
     private Message record(Value value) {
-        return new RecordMessage(new Value[] {value});
+        return new RecordMessage(List.of(value));
     }
 }

--- a/neo4j-bolt-connection-netty/src/test/java/org/neo4j/bolt/connection/netty/impl/messaging/v41/MessageReaderV41Test.java
+++ b/neo4j-bolt-connection-netty/src/test/java/org/neo4j/bolt/connection/netty/impl/messaging/v41/MessageReaderV41Test.java
@@ -100,6 +100,6 @@ public class MessageReaderV41Test extends AbstractMessageReaderTestBase {
     }
 
     private Message record(Value value) {
-        return new RecordMessage(new Value[] {value});
+        return new RecordMessage(List.of(value));
     }
 }

--- a/neo4j-bolt-connection-netty/src/test/java/org/neo4j/bolt/connection/netty/impl/messaging/v42/MessageReaderV42Test.java
+++ b/neo4j-bolt-connection-netty/src/test/java/org/neo4j/bolt/connection/netty/impl/messaging/v42/MessageReaderV42Test.java
@@ -100,6 +100,6 @@ public class MessageReaderV42Test extends AbstractMessageReaderTestBase {
     }
 
     private Message record(Value value) {
-        return new RecordMessage(new Value[] {value});
+        return new RecordMessage(List.of(value));
     }
 }

--- a/neo4j-bolt-connection-netty/src/test/java/org/neo4j/bolt/connection/netty/impl/messaging/v43/MessageReaderV43Test.java
+++ b/neo4j-bolt-connection-netty/src/test/java/org/neo4j/bolt/connection/netty/impl/messaging/v43/MessageReaderV43Test.java
@@ -101,6 +101,6 @@ public class MessageReaderV43Test extends AbstractMessageReaderTestBase {
     }
 
     private Message record(Value value) {
-        return new RecordMessage(new Value[] {value});
+        return new RecordMessage(List.of(value));
     }
 }

--- a/neo4j-bolt-connection-netty/src/test/java/org/neo4j/bolt/connection/netty/impl/messaging/v44/MessageReaderV44Test.java
+++ b/neo4j-bolt-connection-netty/src/test/java/org/neo4j/bolt/connection/netty/impl/messaging/v44/MessageReaderV44Test.java
@@ -99,6 +99,6 @@ public class MessageReaderV44Test extends AbstractMessageReaderTestBase {
     }
 
     private Message record(Value value) {
-        return new RecordMessage(new Value[] {value});
+        return new RecordMessage(List.of(value));
     }
 }

--- a/neo4j-bolt-connection-netty/src/test/java/org/neo4j/bolt/connection/netty/impl/messaging/v5/MessageReaderV5Test.java
+++ b/neo4j-bolt-connection-netty/src/test/java/org/neo4j/bolt/connection/netty/impl/messaging/v5/MessageReaderV5Test.java
@@ -99,7 +99,7 @@ public class MessageReaderV5Test extends AbstractMessageReaderTestBase {
     }
 
     private Message record(Value value) {
-        return new RecordMessage(new Value[] {value});
+        return new RecordMessage(List.of(value));
     }
 
     @Override

--- a/neo4j-bolt-connection-netty/src/test/java/org/neo4j/bolt/connection/netty/impl/messaging/v57/MessageReaderV57Test.java
+++ b/neo4j-bolt-connection-netty/src/test/java/org/neo4j/bolt/connection/netty/impl/messaging/v57/MessageReaderV57Test.java
@@ -134,6 +134,6 @@ class MessageReaderV57Test extends AbstractMessageReaderTestBase {
     }
 
     private Message record(Value value) {
-        return new RecordMessage(new Value[] {value});
+        return new RecordMessage(List.of(value));
     }
 }

--- a/neo4j-bolt-connection-netty/src/test/java/org/neo4j/bolt/connection/netty/impl/util/messaging/KnowledgeableMessageFormat.java
+++ b/neo4j-bolt-connection-netty/src/test/java/org/neo4j/bolt/connection/netty/impl/util/messaging/KnowledgeableMessageFormat.java
@@ -103,7 +103,7 @@ public class KnowledgeableMessageFormat extends MessageFormatV3 {
 
         @Override
         protected void packInternalValue(Value value) throws IOException {
-            switch (value.type()) {
+            switch (value.boltValueType()) {
                 case NODE -> {
                     var node = ((TestValue) value).asNode();
                     packNode(node);

--- a/neo4j-bolt-connection-netty/src/test/java/org/neo4j/bolt/connection/netty/impl/util/messaging/MemorizingInboundMessageDispatcher.java
+++ b/neo4j-bolt-connection-netty/src/test/java/org/neo4j/bolt/connection/netty/impl/util/messaging/MemorizingInboundMessageDispatcher.java
@@ -48,7 +48,7 @@ public class MemorizingInboundMessageDispatcher extends InboundMessageDispatcher
     }
 
     @Override
-    public void handleRecordMessage(Value[] fields) {
+    public void handleRecordMessage(List<Value> fields) {
         messages.add(new RecordMessage(fields));
     }
 

--- a/neo4j-bolt-connection-pooled/pom.xml
+++ b/neo4j-bolt-connection-pooled/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.neo4j.bolt</groupId>
         <artifactId>neo4j-bolt-connection-parent</artifactId>
-        <version>4.1-SNAPSHOT</version>
+        <version>5.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>neo4j-bolt-connection-pooled</artifactId>

--- a/neo4j-bolt-connection-pooled/src/main/java/org/neo4j/bolt/connection/pooled/impl/PooledBoltConnection.java
+++ b/neo4j-bolt-connection-pooled/src/main/java/org/neo4j/bolt/connection/pooled/impl/PooledBoltConnection.java
@@ -200,7 +200,7 @@ public class PooledBoltConnection implements BoltConnection {
         }
 
         @Override
-        public void onRecord(Value[] fields) {
+        public void onRecord(List<Value> fields) {
             handler.onRecord(fields);
         }
 

--- a/neo4j-bolt-connection-query-api/pom.xml
+++ b/neo4j-bolt-connection-query-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.neo4j.bolt</groupId>
         <artifactId>neo4j-bolt-connection-parent</artifactId>
-        <version>4.1-SNAPSHOT</version>
+        <version>5.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>neo4j-bolt-connection-query-api</artifactId>

--- a/neo4j-bolt-connection-query-api/src/main/java/org/neo4j/bolt/connection/query_api/impl/CypherTypes.java
+++ b/neo4j-bolt-connection-query-api/src/main/java/org/neo4j/bolt/connection/query_api/impl/CypherTypes.java
@@ -41,13 +41,13 @@ enum CypherTypes {
     List(
         Type.LIST,
         null, // manually handled in JSON converter
-        (v) -> v.values()
+        (v) -> v.boltValues()
     ),
 
     Map(
         Type.MAP,
         null, // manually handled in JSON converter
-        (v) -> v.asMap(Function.identity())
+        Value::asBoltMap
     ),
 
     Boolean(
@@ -124,7 +124,7 @@ enum CypherTypes {
     Duration(
         Type.DURATION,
         CypherTypes::parseDuration,
-        (v) -> v.asIsoDuration().toString()
+        (v) -> v.asBoltIsoDuration().toString()
     ),
 
     Point(
@@ -162,14 +162,14 @@ enum CypherTypes {
     }
 
     public static CypherTypes typeFromValue(Value value) {
-        var valueType = value.type();
+        var valueType = value.boltValueType();
         for (CypherTypes cypherType : values()) {
             if (cypherType.type == valueType) {
                 return cypherType;
             }
         }
 
-        throw new IllegalArgumentException("no Cypher type found representing " + value.type());
+        throw new IllegalArgumentException("no Cypher type found representing " + value.boltValueType());
     }
 
     /**
@@ -208,8 +208,8 @@ enum CypherTypes {
     }
 
     private static String writePoint(Value value) {
-        if (value.type() == Type.POINT) {
-            var point = value.asPoint();
+        if (value.boltValueType() == Type.POINT) {
+            var point = value.asBoltPoint();
             var srid = point.srid();
             String pointArguments;
             if (Double.isNaN(point.z())) {

--- a/neo4j-bolt-connection-query-api/src/main/java/org/neo4j/bolt/connection/query_api/impl/PullMessageHandler.java
+++ b/neo4j-bolt-connection-query-api/src/main/java/org/neo4j/bolt/connection/query_api/impl/PullMessageHandler.java
@@ -17,6 +17,7 @@
 package org.neo4j.bolt.connection.query_api.impl;
 
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
@@ -52,7 +53,7 @@ final class PullMessageHandler implements MessageHandler<Void> {
     public CompletionStage<Void> exchange() {
         return CompletableFuture.<Void>completedStage(null).thenApply(ignored -> {
             var query = queryFinder.apply(message.qid());
-            var records = new ArrayList<Value[]>();
+            var records = new ArrayList<List<Value>>();
             var deleted = false;
 
             var request = message.request() > 0 ? message.request() : Long.MAX_VALUE;

--- a/neo4j-bolt-connection-query-api/src/main/java/org/neo4j/bolt/connection/query_api/impl/Query.java
+++ b/neo4j-bolt-connection-query-api/src/main/java/org/neo4j/bolt/connection/query_api/impl/Query.java
@@ -20,4 +20,4 @@ import java.util.List;
 import java.util.Map;
 import org.neo4j.bolt.connection.values.Value;
 
-record Query(long id, List<String> fields, List<Value[]> values, Map<String, Value> metadata) {}
+record Query(long id, List<String> fields, List<List<Value>> values, Map<String, Value> metadata) {}

--- a/neo4j-bolt-connection-query-api/src/main/java/org/neo4j/bolt/connection/query_api/impl/QueryData.java
+++ b/neo4j-bolt-connection-query-api/src/main/java/org/neo4j/bolt/connection/query_api/impl/QueryData.java
@@ -19,4 +19,4 @@ package org.neo4j.bolt.connection.query_api.impl;
 import java.util.List;
 import org.neo4j.bolt.connection.values.Value;
 
-public record QueryData(List<String> fields, List<Value[]> values) {}
+public record QueryData(List<String> fields, List<List<Value>> values) {}

--- a/neo4j-bolt-connection-query-api/src/test/java/org/neo4j/bolt/connection/query_api/impl/AbstractQueryApi.java
+++ b/neo4j-bolt-connection-query-api/src/test/java/org/neo4j/bolt/connection/query_api/impl/AbstractQueryApi.java
@@ -16,7 +16,6 @@
  */
 package org.neo4j.bolt.connection.query_api.impl;
 
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
@@ -209,6 +208,7 @@ abstract class AbstractQueryApi {
         assertEquals("Database name must be specified", boltException.getMessage());
     }
 
+    @SuppressWarnings("unchecked")
     @Test
     void shouldRunAutocommitAndPullAll() {
         // given
@@ -241,7 +241,7 @@ abstract class AbstractQueryApi {
 
         // then
         var runSummaryCaptor = ArgumentCaptor.forClass(RunSummary.class);
-        var valuesCaptor = ArgumentCaptor.forClass(Value[].class);
+        var valuesCaptor = ArgumentCaptor.forClass(List.class);
         var pullSummaryCaptor = ArgumentCaptor.forClass(PullSummary.class);
         var responseHandlerInOrder = inOrder(responseHandler);
         responseHandlerInOrder.verify(responseHandler).onRunSummary(runSummaryCaptor.capture());
@@ -257,8 +257,8 @@ abstract class AbstractQueryApi {
         assertEquals(-1, runSummary.resultAvailableAfter());
         assertEquals(database(), runSummary.databaseName().orElse(null));
 
-        var values = valuesCaptor.getValue();
-        assertArrayEquals(new Value[] {TestValueFactory.INSTANCE.value(1L)}, values);
+        var values = (List<Value>) valuesCaptor.getValue();
+        assertEquals(List.of(TestValueFactory.INSTANCE.value(1L)), values);
 
         var pullSummary = pullSummaryCaptor.getValue();
         assertNotNull(pullSummary);
@@ -321,6 +321,7 @@ abstract class AbstractQueryApi {
         assertFalse(discardSummary.metadata().get("bookmark").isEmpty());
     }
 
+    @SuppressWarnings("unchecked")
     @Test
     void shouldRunAutocommitAndPullAllLater() {
         // given
@@ -367,7 +368,7 @@ abstract class AbstractQueryApi {
                 .join();
 
         // then
-        var valuesCaptor = ArgumentCaptor.forClass(Value[].class);
+        var valuesCaptor = ArgumentCaptor.forClass(List.class);
         var pullSummaryCaptor = ArgumentCaptor.forClass(PullSummary.class);
         var responseHandlerInOrder = inOrder(responseHandler);
         responseHandlerInOrder.verify(responseHandler).onRecord(valuesCaptor.capture());
@@ -376,7 +377,7 @@ abstract class AbstractQueryApi {
         then(responseHandler).shouldHaveNoMoreInteractions();
 
         var values = valuesCaptor.getValue();
-        assertArrayEquals(new Value[] {TestValueFactory.INSTANCE.value(1L)}, values);
+        assertEquals(List.of(TestValueFactory.INSTANCE.value(1L)), values);
 
         var pullSummary = pullSummaryCaptor.getValue();
         assertNotNull(pullSummary);
@@ -425,6 +426,7 @@ abstract class AbstractQueryApi {
         assertEquals(database(), beginSummary.databaseName().orElse(null));
     }
 
+    @SuppressWarnings("unchecked")
     @Test
     void shouldBeginTransactionAndRunAndPull() {
         // given
@@ -458,7 +460,7 @@ abstract class AbstractQueryApi {
         // then
         var beginSummaryCaptor = ArgumentCaptor.forClass(BeginSummary.class);
         var runSummaryCaptor = ArgumentCaptor.forClass(RunSummary.class);
-        var valuesCaptor = ArgumentCaptor.forClass(Value[].class);
+        var valuesCaptor = ArgumentCaptor.forClass(List.class);
         var pullSummaryCaptor = ArgumentCaptor.forClass(PullSummary.class);
         var responseHandlerInOrder = inOrder(responseHandler);
         responseHandlerInOrder.verify(responseHandler).onBeginSummary(beginSummaryCaptor.capture());
@@ -480,7 +482,7 @@ abstract class AbstractQueryApi {
         assertEquals(database(), runSummary.databaseName().orElse(null));
 
         var values = valuesCaptor.getValue();
-        assertArrayEquals(new Value[] {TestValueFactory.INSTANCE.value(1L)}, values);
+        assertEquals(List.of(TestValueFactory.INSTANCE.value(1L)), values);
 
         var pullSummary = pullSummaryCaptor.getValue();
         assertNotNull(pullSummary);
@@ -489,6 +491,7 @@ abstract class AbstractQueryApi {
         assertFalse(pullSummary.metadata().containsKey("bookmark"));
     }
 
+    @SuppressWarnings("unchecked")
     @Test
     void shouldBeginTransactionAndRunAndPullAndCommit() {
         // given
@@ -523,7 +526,7 @@ abstract class AbstractQueryApi {
         // then
         var beginSummaryCaptor = ArgumentCaptor.forClass(BeginSummary.class);
         var runSummaryCaptor = ArgumentCaptor.forClass(RunSummary.class);
-        var valuesCaptor = ArgumentCaptor.forClass(Value[].class);
+        var valuesCaptor = ArgumentCaptor.forClass(List.class);
         var pullSummaryCaptor = ArgumentCaptor.forClass(PullSummary.class);
         var commitSummaryCaptor = ArgumentCaptor.forClass(CommitSummary.class);
         var responseHandlerInOrder = inOrder(responseHandler);
@@ -547,7 +550,7 @@ abstract class AbstractQueryApi {
         assertEquals(database(), runSummary.databaseName().orElse(null));
 
         var values = valuesCaptor.getValue();
-        assertArrayEquals(new Value[] {TestValueFactory.INSTANCE.value(1L)}, values);
+        assertEquals(List.of(TestValueFactory.INSTANCE.value(1L)), values);
 
         var pullSummary = pullSummaryCaptor.getValue();
         assertNotNull(pullSummary);
@@ -561,6 +564,7 @@ abstract class AbstractQueryApi {
         assertFalse(commitSummary.bookmark().get().isEmpty());
     }
 
+    @SuppressWarnings("unchecked")
     @Test
     void shouldBeginTransactionAndRunAndPullAndRollback() {
         // given
@@ -595,7 +599,7 @@ abstract class AbstractQueryApi {
         // then
         var beginSummaryCaptor = ArgumentCaptor.forClass(BeginSummary.class);
         var runSummaryCaptor = ArgumentCaptor.forClass(RunSummary.class);
-        var valuesCaptor = ArgumentCaptor.forClass(Value[].class);
+        var valuesCaptor = ArgumentCaptor.forClass(List.class);
         var pullSummaryCaptor = ArgumentCaptor.forClass(PullSummary.class);
         var rollbackSummaryCaptor = ArgumentCaptor.forClass(RollbackSummary.class);
         var responseHandlerInOrder = inOrder(responseHandler);
@@ -619,7 +623,7 @@ abstract class AbstractQueryApi {
         assertEquals(database(), runSummary.databaseName().orElse(null));
 
         var values = valuesCaptor.getValue();
-        assertArrayEquals(new Value[] {TestValueFactory.INSTANCE.value(1L)}, values);
+        assertEquals(List.of(TestValueFactory.INSTANCE.value(1L)), values);
 
         var pullSummary = pullSummaryCaptor.getValue();
         assertNotNull(pullSummary);

--- a/neo4j-bolt-connection-routed/pom.xml
+++ b/neo4j-bolt-connection-routed/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.neo4j.bolt</groupId>
         <artifactId>neo4j-bolt-connection-parent</artifactId>
-        <version>4.1-SNAPSHOT</version>
+        <version>5.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>neo4j-bolt-connection-routed</artifactId>

--- a/neo4j-bolt-connection-routed/src/main/java/org/neo4j/bolt/connection/routed/impl/RoutedBoltConnection.java
+++ b/neo4j-bolt-connection-routed/src/main/java/org/neo4j/bolt/connection/routed/impl/RoutedBoltConnection.java
@@ -168,7 +168,7 @@ public class RoutedBoltConnection implements BoltConnection {
         }
 
         @Override
-        public void onRecord(Value[] fields) {
+        public void onRecord(List<Value> fields) {
             handler.onRecord(fields);
         }
 

--- a/neo4j-bolt-connection-test-values/pom.xml
+++ b/neo4j-bolt-connection-test-values/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.neo4j.bolt</groupId>
         <artifactId>neo4j-bolt-connection-parent</artifactId>
-        <version>4.1-SNAPSHOT</version>
+        <version>5.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>neo4j-bolt-connection-test-values</artifactId>

--- a/neo4j-bolt-connection-test-values/src/main/java/org/neo4j/bolt/connection/test/values/Values.java
+++ b/neo4j-bolt-connection-test-values/src/main/java/org/neo4j/bolt/connection/test/values/Values.java
@@ -31,6 +31,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import org.neo4j.bolt.connection.test.values.impl.AsValue;
@@ -41,9 +42,9 @@ import org.neo4j.bolt.connection.test.values.impl.DateValue;
 import org.neo4j.bolt.connection.test.values.impl.DurationValue;
 import org.neo4j.bolt.connection.test.values.impl.FloatValue;
 import org.neo4j.bolt.connection.test.values.impl.IntegerValue;
-import org.neo4j.bolt.connection.test.values.impl.InternalIsoDuration;
-import org.neo4j.bolt.connection.test.values.impl.InternalPoint2D;
-import org.neo4j.bolt.connection.test.values.impl.InternalPoint3D;
+import org.neo4j.bolt.connection.test.values.impl.InternalBoltIsoDuration;
+import org.neo4j.bolt.connection.test.values.impl.InternalBoltPoint2D;
+import org.neo4j.bolt.connection.test.values.impl.InternalBoltPoint3D;
 import org.neo4j.bolt.connection.test.values.impl.ListValue;
 import org.neo4j.bolt.connection.test.values.impl.LocalDateTimeValue;
 import org.neo4j.bolt.connection.test.values.impl.LocalTimeValue;
@@ -210,7 +211,7 @@ final class Values {
         var size = input.length;
         var values = new Value[size];
         System.arraycopy(input, 0, values, 0, size);
-        return new ListValue(values);
+        return new ListValue(Arrays.asList(values));
     }
 
     /**
@@ -230,7 +231,9 @@ final class Values {
      * @return the value
      */
     public static Value value(String... input) {
-        var values = Arrays.stream(input).map(StringValue::new).toArray(StringValue[]::new);
+        var values = Arrays.stream(input)
+                .map(StringValue::new)
+                .collect(Collectors.toCollection(() -> new ArrayList<>(input.length)));
         return new ListValue(values);
     }
 
@@ -241,8 +244,9 @@ final class Values {
      * @return the value
      */
     public static Value value(boolean... input) {
-        var values =
-                IntStream.range(0, input.length).mapToObj(i -> value(input[i])).toArray(Value[]::new);
+        var values = IntStream.range(0, input.length)
+                .mapToObj(i -> value(input[i]))
+                .collect(Collectors.toCollection(() -> new ArrayList<>(input.length)));
         return new ListValue(values);
     }
 
@@ -253,8 +257,9 @@ final class Values {
      * @return the value
      */
     public static Value value(char... input) {
-        var values =
-                IntStream.range(0, input.length).mapToObj(i -> value(input[i])).toArray(Value[]::new);
+        var values = IntStream.range(0, input.length)
+                .mapToObj(i -> value(input[i]))
+                .collect(Collectors.toCollection(() -> new ArrayList<>(input.length)));
         return new ListValue(values);
     }
 
@@ -265,7 +270,9 @@ final class Values {
      * @return the value
      */
     public static Value value(long... input) {
-        var values = Arrays.stream(input).mapToObj(Values::value).toArray(Value[]::new);
+        var values = Arrays.stream(input)
+                .mapToObj(Values::value)
+                .collect(Collectors.toCollection(() -> new ArrayList<>(input.length)));
         return new ListValue(values);
     }
 
@@ -276,8 +283,9 @@ final class Values {
      * @return the value
      */
     public static Value value(short... input) {
-        var values =
-                IntStream.range(0, input.length).mapToObj(i -> value(input[i])).toArray(Value[]::new);
+        var values = IntStream.range(0, input.length)
+                .mapToObj(i -> value(input[i]))
+                .collect(Collectors.toCollection(() -> new ArrayList<>(input.length)));
         return new ListValue(values);
     }
 
@@ -288,7 +296,9 @@ final class Values {
      * @return the value
      */
     public static Value value(int... input) {
-        var values = Arrays.stream(input).mapToObj(Values::value).toArray(Value[]::new);
+        var values = Arrays.stream(input)
+                .mapToObj(Values::value)
+                .collect(Collectors.toCollection(() -> new ArrayList<>(input.length)));
         return new ListValue(values);
     }
 
@@ -299,7 +309,9 @@ final class Values {
      * @return the value
      */
     public static Value value(double... input) {
-        var values = Arrays.stream(input).mapToObj(Values::value).toArray(Value[]::new);
+        var values = Arrays.stream(input)
+                .mapToObj(Values::value)
+                .collect(Collectors.toCollection(() -> new ArrayList<>(input.length)));
         return new ListValue(values);
     }
 
@@ -310,8 +322,9 @@ final class Values {
      * @return the value
      */
     public static Value value(float... input) {
-        var values =
-                IntStream.range(0, input.length).mapToObj(i -> value(input[i])).toArray(Value[]::new);
+        var values = IntStream.range(0, input.length)
+                .mapToObj(i -> value(input[i]))
+                .collect(Collectors.toCollection(() -> new ArrayList<>(input.length)));
         return new ListValue(values);
     }
 
@@ -327,7 +340,7 @@ final class Values {
         for (var val : vals) {
             values[i++] = value(val);
         }
-        return new ListValue(values);
+        return new ListValue(Arrays.asList(values));
     }
 
     /**
@@ -351,7 +364,7 @@ final class Values {
         while (val.hasNext()) {
             values.add(value(val.next()));
         }
-        return new ListValue(values.toArray(new Value[0]));
+        return new ListValue(values);
     }
 
     /**
@@ -361,7 +374,7 @@ final class Values {
      * @return the value
      */
     public static Value value(Stream<Object> stream) {
-        var values = stream.map(Values::value).toArray(Value[]::new);
+        var values = stream.map(Values::value).toList();
         return new ListValue(values);
     }
 
@@ -506,7 +519,7 @@ final class Values {
      * @return the value
      */
     public static Value value(Period period) {
-        return value(new InternalIsoDuration(period));
+        return value(new InternalBoltIsoDuration(period));
     }
 
     /**
@@ -516,7 +529,7 @@ final class Values {
      * @return the value
      */
     public static Value value(Duration duration) {
-        return value(new InternalIsoDuration(duration));
+        return value(new InternalBoltIsoDuration(duration));
     }
 
     /**
@@ -529,7 +542,7 @@ final class Values {
      * @return the value
      */
     public static Value isoDuration(long months, long days, long seconds, int nanoseconds) {
-        return value(new InternalIsoDuration(months, days, seconds, nanoseconds));
+        return value(new InternalBoltIsoDuration(months, days, seconds, nanoseconds));
     }
 
     /**
@@ -551,7 +564,7 @@ final class Values {
      * @return the value
      */
     public static Value point(int srid, double x, double y) {
-        return value(new InternalPoint2D(srid, x, y));
+        return value(new InternalBoltPoint2D(srid, x, y));
     }
 
     /**
@@ -574,6 +587,6 @@ final class Values {
      * @return the value
      */
     public static Value point(int srid, double x, double y, double z) {
-        return value(new InternalPoint3D(srid, x, y, z));
+        return value(new InternalBoltPoint3D(srid, x, y, z));
     }
 }

--- a/neo4j-bolt-connection-test-values/src/main/java/org/neo4j/bolt/connection/test/values/impl/BooleanValue.java
+++ b/neo4j-bolt-connection-test-values/src/main/java/org/neo4j/bolt/connection/test/values/impl/BooleanValue.java
@@ -31,7 +31,7 @@ public abstract class BooleanValue extends ValueAdapter {
     }
 
     @Override
-    public Type type() {
+    public Type boltValueType() {
         return Type.BOOLEAN;
     }
 

--- a/neo4j-bolt-connection-test-values/src/main/java/org/neo4j/bolt/connection/test/values/impl/BytesValue.java
+++ b/neo4j-bolt-connection-test-values/src/main/java/org/neo4j/bolt/connection/test/values/impl/BytesValue.java
@@ -45,7 +45,7 @@ public class BytesValue extends ValueAdapter {
     }
 
     @Override
-    public Type type() {
+    public Type boltValueType() {
         return Type.BYTES;
     }
 

--- a/neo4j-bolt-connection-test-values/src/main/java/org/neo4j/bolt/connection/test/values/impl/DateTimeValue.java
+++ b/neo4j-bolt-connection-test-values/src/main/java/org/neo4j/bolt/connection/test/values/impl/DateTimeValue.java
@@ -30,7 +30,7 @@ public class DateTimeValue extends ObjectValueAdapter<ZonedDateTime> {
     }
 
     @Override
-    public Type type() {
+    public Type boltValueType() {
         return Type.DATE_TIME;
     }
 }

--- a/neo4j-bolt-connection-test-values/src/main/java/org/neo4j/bolt/connection/test/values/impl/DateValue.java
+++ b/neo4j-bolt-connection-test-values/src/main/java/org/neo4j/bolt/connection/test/values/impl/DateValue.java
@@ -30,7 +30,7 @@ public class DateValue extends ObjectValueAdapter<LocalDate> {
     }
 
     @Override
-    public Type type() {
+    public Type boltValueType() {
         return Type.DATE;
     }
 }

--- a/neo4j-bolt-connection-test-values/src/main/java/org/neo4j/bolt/connection/test/values/impl/DurationValue.java
+++ b/neo4j-bolt-connection-test-values/src/main/java/org/neo4j/bolt/connection/test/values/impl/DurationValue.java
@@ -25,12 +25,12 @@ public class DurationValue extends ObjectValueAdapter<IsoDuration> {
     }
 
     @Override
-    public IsoDuration asIsoDuration() {
+    public IsoDuration asBoltIsoDuration() {
         return asObject();
     }
 
     @Override
-    public Type type() {
+    public Type boltValueType() {
         return Type.DURATION;
     }
 }

--- a/neo4j-bolt-connection-test-values/src/main/java/org/neo4j/bolt/connection/test/values/impl/EntityValueAdapter.java
+++ b/neo4j-bolt-connection-test-values/src/main/java/org/neo4j/bolt/connection/test/values/impl/EntityValueAdapter.java
@@ -30,8 +30,8 @@ public abstract class EntityValueAdapter<V extends Entity> extends ObjectValueAd
     }
 
     @Override
-    public <T> Map<String, T> asMap(Function<Value, T> mapFunction) {
-        return asEntity().asMap(mapFunction);
+    public Map<String, Value> asBoltMap() {
+        return asEntity().asMap(Function.identity());
     }
 
     @Override
@@ -45,7 +45,7 @@ public abstract class EntityValueAdapter<V extends Entity> extends ObjectValueAd
     }
 
     @Override
-    public Value get(String key) {
+    public Value getBoltValue(String key) {
         return asEntity().get(key);
     }
 }

--- a/neo4j-bolt-connection-test-values/src/main/java/org/neo4j/bolt/connection/test/values/impl/FloatValue.java
+++ b/neo4j-bolt-connection-test-values/src/main/java/org/neo4j/bolt/connection/test/values/impl/FloatValue.java
@@ -26,7 +26,7 @@ public class FloatValue extends NumberValueAdapter<Double> {
     }
 
     @Override
-    public Type type() {
+    public Type boltValueType() {
         return Type.FLOAT;
     }
 
@@ -39,7 +39,7 @@ public class FloatValue extends NumberValueAdapter<Double> {
     public long asLong() {
         var longVal = (long) val;
         if ((double) longVal != val) {
-            throw new LossyCoercion(type().name(), "Java long");
+            throw new LossyCoercion(boltValueType().name(), "Java long");
         }
 
         return longVal;

--- a/neo4j-bolt-connection-test-values/src/main/java/org/neo4j/bolt/connection/test/values/impl/IntegerValue.java
+++ b/neo4j-bolt-connection-test-values/src/main/java/org/neo4j/bolt/connection/test/values/impl/IntegerValue.java
@@ -26,7 +26,7 @@ public class IntegerValue extends NumberValueAdapter<Long> {
     }
 
     @Override
-    public Type type() {
+    public Type boltValueType() {
         return Type.INTEGER;
     }
 
@@ -44,7 +44,7 @@ public class IntegerValue extends NumberValueAdapter<Long> {
     public double asDouble() {
         var doubleVal = (double) val;
         if ((long) doubleVal != val) {
-            throw new LossyCoercion(type().name(), "Java double");
+            throw new LossyCoercion(boltValueType().name(), "Java double");
         }
 
         return (double) val;

--- a/neo4j-bolt-connection-test-values/src/main/java/org/neo4j/bolt/connection/test/values/impl/InternalBoltIsoDuration.java
+++ b/neo4j-bolt-connection-test-values/src/main/java/org/neo4j/bolt/connection/test/values/impl/InternalBoltIsoDuration.java
@@ -28,7 +28,7 @@ import java.util.List;
 import java.util.Objects;
 import org.neo4j.bolt.connection.values.IsoDuration;
 
-public class InternalIsoDuration implements IsoDuration {
+public class InternalBoltIsoDuration implements IsoDuration {
     private static final long NANOS_PER_SECOND = 1_000_000_000;
     private static final List<TemporalUnit> SUPPORTED_UNITS = List.of(MONTHS, DAYS, SECONDS, NANOS);
 
@@ -37,19 +37,19 @@ public class InternalIsoDuration implements IsoDuration {
     private final long seconds;
     private final int nanoseconds;
 
-    public InternalIsoDuration(Period period) {
+    public InternalBoltIsoDuration(Period period) {
         this(period.toTotalMonths(), period.getDays(), Duration.ZERO);
     }
 
-    public InternalIsoDuration(Duration duration) {
+    public InternalBoltIsoDuration(Duration duration) {
         this(0, 0, duration);
     }
 
-    public InternalIsoDuration(long months, long days, long seconds, int nanoseconds) {
+    public InternalBoltIsoDuration(long months, long days, long seconds, int nanoseconds) {
         this(months, days, Duration.ofSeconds(seconds, nanoseconds));
     }
 
-    InternalIsoDuration(long months, long days, Duration duration) {
+    InternalBoltIsoDuration(long months, long days, Duration duration) {
         this.months = months;
         this.days = days;
         this.seconds = duration.getSeconds(); // normalized value of seconds
@@ -84,7 +84,7 @@ public class InternalIsoDuration implements IsoDuration {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        var that = (InternalIsoDuration) o;
+        var that = (InternalBoltIsoDuration) o;
         return months == that.months && days == that.days && seconds == that.seconds && nanoseconds == that.nanoseconds;
     }
 

--- a/neo4j-bolt-connection-test-values/src/main/java/org/neo4j/bolt/connection/test/values/impl/InternalBoltPoint2D.java
+++ b/neo4j-bolt-connection-test-values/src/main/java/org/neo4j/bolt/connection/test/values/impl/InternalBoltPoint2D.java
@@ -18,7 +18,7 @@ package org.neo4j.bolt.connection.test.values.impl;
 
 import org.neo4j.bolt.connection.values.Point;
 
-public record InternalPoint2D(int srid, double x, double y) implements Point {
+public record InternalBoltPoint2D(int srid, double x, double y) implements Point {
 
     @Override
     public double z() {
@@ -33,7 +33,7 @@ public record InternalPoint2D(int srid, double x, double y) implements Point {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        var that = (InternalPoint2D) o;
+        var that = (InternalBoltPoint2D) o;
         return srid == that.srid && Double.compare(that.x, x) == 0 && Double.compare(that.y, y) == 0;
     }
 

--- a/neo4j-bolt-connection-test-values/src/main/java/org/neo4j/bolt/connection/test/values/impl/InternalBoltPoint3D.java
+++ b/neo4j-bolt-connection-test-values/src/main/java/org/neo4j/bolt/connection/test/values/impl/InternalBoltPoint3D.java
@@ -18,7 +18,7 @@ package org.neo4j.bolt.connection.test.values.impl;
 
 import org.neo4j.bolt.connection.values.Point;
 
-public record InternalPoint3D(int srid, double x, double y, double z) implements Point {
+public record InternalBoltPoint3D(int srid, double x, double y, double z) implements Point {
 
     @Override
     public boolean equals(Object o) {
@@ -28,7 +28,7 @@ public record InternalPoint3D(int srid, double x, double y, double z) implements
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        var that = (InternalPoint3D) o;
+        var that = (InternalBoltPoint3D) o;
         return srid == that.srid
                 && Double.compare(that.x, x) == 0
                 && Double.compare(that.y, y) == 0

--- a/neo4j-bolt-connection-test-values/src/main/java/org/neo4j/bolt/connection/test/values/impl/InternalMapAccessorWithDefaultValue.java
+++ b/neo4j-bolt-connection-test-values/src/main/java/org/neo4j/bolt/connection/test/values/impl/InternalMapAccessorWithDefaultValue.java
@@ -19,5 +19,5 @@ package org.neo4j.bolt.connection.test.values.impl;
 import org.neo4j.bolt.connection.values.Value;
 
 public abstract class InternalMapAccessorWithDefaultValue implements Value {
-    public abstract Value get(String key);
+    public abstract Value getBoltValue(String key);
 }

--- a/neo4j-bolt-connection-test-values/src/main/java/org/neo4j/bolt/connection/test/values/impl/ListValue.java
+++ b/neo4j-bolt-connection-test-values/src/main/java/org/neo4j/bolt/connection/test/values/impl/ListValue.java
@@ -16,15 +16,14 @@
  */
 package org.neo4j.bolt.connection.test.values.impl;
 
-import java.util.Arrays;
-import java.util.Iterator;
+import java.util.List;
 import org.neo4j.bolt.connection.values.Type;
 import org.neo4j.bolt.connection.values.Value;
 
 public class ListValue extends ValueAdapter {
-    private final Value[] values;
+    private final List<? extends Value> values;
 
-    public ListValue(Value... values) {
+    public ListValue(List<? extends Value> values) {
         if (values == null) {
             throw new IllegalArgumentException("Cannot construct ListValue from null");
         }
@@ -33,42 +32,28 @@ public class ListValue extends ValueAdapter {
 
     @Override
     public boolean isEmpty() {
-        return values.length == 0;
+        return values.isEmpty();
     }
 
     @Override
     public int size() {
-        return values.length;
+        return values.size();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public Iterable<Value> boltValues() {
+        return (Iterable<Value>) values;
     }
 
     @Override
-    public Iterable<Value> values() {
-        return () -> new Iterator<>() {
-            private int cursor = 0;
-
-            @Override
-            public boolean hasNext() {
-                return cursor < values.length;
-            }
-
-            @Override
-            public Value next() {
-                return values[cursor++];
-            }
-
-            @Override
-            public void remove() {}
-        };
-    }
-
-    @Override
-    public Type type() {
+    public Type boltValueType() {
         return Type.LIST;
     }
 
     @Override
     public String toString() {
-        return Arrays.toString(values);
+        return values.toString();
     }
 
     @Override
@@ -81,11 +66,11 @@ public class ListValue extends ValueAdapter {
         }
 
         var otherValues = (ListValue) o;
-        return Arrays.equals(values, otherValues.values);
+        return values.equals(otherValues.values);
     }
 
     @Override
     public int hashCode() {
-        return Arrays.hashCode(values);
+        return values.hashCode();
     }
 }

--- a/neo4j-bolt-connection-test-values/src/main/java/org/neo4j/bolt/connection/test/values/impl/LocalDateTimeValue.java
+++ b/neo4j-bolt-connection-test-values/src/main/java/org/neo4j/bolt/connection/test/values/impl/LocalDateTimeValue.java
@@ -30,7 +30,7 @@ public class LocalDateTimeValue extends ObjectValueAdapter<LocalDateTime> {
     }
 
     @Override
-    public Type type() {
+    public Type boltValueType() {
         return Type.LOCAL_DATE_TIME;
     }
 }

--- a/neo4j-bolt-connection-test-values/src/main/java/org/neo4j/bolt/connection/test/values/impl/LocalTimeValue.java
+++ b/neo4j-bolt-connection-test-values/src/main/java/org/neo4j/bolt/connection/test/values/impl/LocalTimeValue.java
@@ -30,7 +30,7 @@ public class LocalTimeValue extends ObjectValueAdapter<LocalTime> {
     }
 
     @Override
-    public Type type() {
+    public Type boltValueType() {
         return Type.LOCAL_TIME;
     }
 }

--- a/neo4j-bolt-connection-test-values/src/main/java/org/neo4j/bolt/connection/test/values/impl/MapValue.java
+++ b/neo4j-bolt-connection-test-values/src/main/java/org/neo4j/bolt/connection/test/values/impl/MapValue.java
@@ -37,8 +37,8 @@ public class MapValue extends ValueAdapter {
     }
 
     @Override
-    public <T> Map<String, T> asMap(Function<Value, T> mapFunction) {
-        return Extract.map(val, mapFunction);
+    public Map<String, Value> asBoltMap() {
+        return Extract.map(val, Function.identity());
     }
 
     @Override
@@ -57,12 +57,12 @@ public class MapValue extends ValueAdapter {
     }
 
     @Override
-    public Iterable<Value> values() {
+    public Iterable<Value> boltValues() {
         return val.values();
     }
 
     @Override
-    public Value get(String key) {
+    public Value getBoltValue(String key) {
         var value = val.get(key);
         return value == null ? NullValue.NULL : value;
     }
@@ -73,7 +73,7 @@ public class MapValue extends ValueAdapter {
     }
 
     @Override
-    public Type type() {
+    public Type boltValueType() {
         return Type.MAP;
     }
 

--- a/neo4j-bolt-connection-test-values/src/main/java/org/neo4j/bolt/connection/test/values/impl/NodeValue.java
+++ b/neo4j-bolt-connection-test-values/src/main/java/org/neo4j/bolt/connection/test/values/impl/NodeValue.java
@@ -30,7 +30,7 @@ public class NodeValue extends EntityValueAdapter<TestNode> {
     }
 
     @Override
-    public Type type() {
+    public Type boltValueType() {
         return Type.NODE;
     }
 }

--- a/neo4j-bolt-connection-test-values/src/main/java/org/neo4j/bolt/connection/test/values/impl/NullValue.java
+++ b/neo4j-bolt-connection-test-values/src/main/java/org/neo4j/bolt/connection/test/values/impl/NullValue.java
@@ -35,7 +35,7 @@ public final class NullValue extends ValueAdapter {
     }
 
     @Override
-    public Type type() {
+    public Type boltValueType() {
         return Type.NULL;
     }
 

--- a/neo4j-bolt-connection-test-values/src/main/java/org/neo4j/bolt/connection/test/values/impl/PathValue.java
+++ b/neo4j-bolt-connection-test-values/src/main/java/org/neo4j/bolt/connection/test/values/impl/PathValue.java
@@ -30,7 +30,7 @@ public class PathValue extends ObjectValueAdapter<TestPath> {
     }
 
     @Override
-    public Type type() {
+    public Type boltValueType() {
         return Type.PATH;
     }
 

--- a/neo4j-bolt-connection-test-values/src/main/java/org/neo4j/bolt/connection/test/values/impl/PointValue.java
+++ b/neo4j-bolt-connection-test-values/src/main/java/org/neo4j/bolt/connection/test/values/impl/PointValue.java
@@ -25,12 +25,12 @@ public class PointValue extends ObjectValueAdapter<Point> {
     }
 
     @Override
-    public Point asPoint() {
+    public Point asBoltPoint() {
         return asObject();
     }
 
     @Override
-    public Type type() {
+    public Type boltValueType() {
         return Type.POINT;
     }
 }

--- a/neo4j-bolt-connection-test-values/src/main/java/org/neo4j/bolt/connection/test/values/impl/RelationshipValue.java
+++ b/neo4j-bolt-connection-test-values/src/main/java/org/neo4j/bolt/connection/test/values/impl/RelationshipValue.java
@@ -25,7 +25,7 @@ public class RelationshipValue extends EntityValueAdapter<TestRelationship> {
     }
 
     @Override
-    public Type type() {
+    public Type boltValueType() {
         return Type.RELATIONSHIP;
     }
 

--- a/neo4j-bolt-connection-test-values/src/main/java/org/neo4j/bolt/connection/test/values/impl/StringValue.java
+++ b/neo4j-bolt-connection-test-values/src/main/java/org/neo4j/bolt/connection/test/values/impl/StringValue.java
@@ -50,7 +50,7 @@ public class StringValue extends ValueAdapter {
     }
 
     @Override
-    public Type type() {
+    public Type boltValueType() {
         return Type.STRING;
     }
 

--- a/neo4j-bolt-connection-test-values/src/main/java/org/neo4j/bolt/connection/test/values/impl/TimeValue.java
+++ b/neo4j-bolt-connection-test-values/src/main/java/org/neo4j/bolt/connection/test/values/impl/TimeValue.java
@@ -30,7 +30,7 @@ public class TimeValue extends ObjectValueAdapter<OffsetTime> {
     }
 
     @Override
-    public Type type() {
+    public Type boltValueType() {
         return Type.TIME;
     }
 }

--- a/neo4j-bolt-connection-test-values/src/main/java/org/neo4j/bolt/connection/test/values/impl/UnsupportedDateTimeValue.java
+++ b/neo4j-bolt-connection-test-values/src/main/java/org/neo4j/bolt/connection/test/values/impl/UnsupportedDateTimeValue.java
@@ -34,7 +34,7 @@ public class UnsupportedDateTimeValue extends ValueAdapter {
     }
 
     @Override
-    public Type type() {
+    public Type boltValueType() {
         return Type.DATE_TIME;
     }
 

--- a/neo4j-bolt-connection-test-values/src/main/java/org/neo4j/bolt/connection/test/values/impl/ValueAdapter.java
+++ b/neo4j-bolt-connection-test-values/src/main/java/org/neo4j/bolt/connection/test/values/impl/ValueAdapter.java
@@ -24,7 +24,6 @@ import java.time.LocalTime;
 import java.time.OffsetTime;
 import java.time.ZonedDateTime;
 import java.util.Map;
-import java.util.function.Function;
 import org.neo4j.bolt.connection.test.values.TestNode;
 import org.neo4j.bolt.connection.test.values.TestPath;
 import org.neo4j.bolt.connection.test.values.TestRelationship;
@@ -46,77 +45,77 @@ public abstract class ValueAdapter extends InternalMapAccessorWithDefaultValue i
 
     @Override
     public boolean containsKey(String key) {
-        throw new NotMultiValued(type().name() + " is not a keyed collection");
+        throw new NotMultiValued(boltValueType().name() + " is not a keyed collection");
     }
 
     @Override
     public String asString() {
-        throw new Uncoercible(type().name(), "Java String");
+        throw new Uncoercible(boltValueType().name(), "Java String");
     }
 
     @Override
     public long asLong() {
-        throw new Uncoercible(type().name(), "Java long");
+        throw new Uncoercible(boltValueType().name(), "Java long");
     }
 
     @Override
     public double asDouble() {
-        throw new Uncoercible(type().name(), "Java double");
+        throw new Uncoercible(boltValueType().name(), "Java double");
     }
 
     @Override
     public boolean asBoolean() {
-        throw new Uncoercible(type().name(), "Java boolean");
+        throw new Uncoercible(boltValueType().name(), "Java boolean");
     }
 
     @Override
-    public <T> Map<String, T> asMap(Function<Value, T> mapFunction) {
-        throw new Uncoercible(type().name(), "Java Map");
+    public Map<String, Value> asBoltMap() {
+        throw new Uncoercible(boltValueType().name(), "Java Map");
     }
 
     @Override
     public LocalDate asLocalDate() {
-        throw new Uncoercible(type().name(), "LocalDate");
+        throw new Uncoercible(boltValueType().name(), "LocalDate");
     }
 
     @Override
     public OffsetTime asOffsetTime() {
-        throw new Uncoercible(type().name(), "OffsetTime");
+        throw new Uncoercible(boltValueType().name(), "OffsetTime");
     }
 
     @Override
     public LocalTime asLocalTime() {
-        throw new Uncoercible(type().name(), "LocalTime");
+        throw new Uncoercible(boltValueType().name(), "LocalTime");
     }
 
     @Override
     public LocalDateTime asLocalDateTime() {
-        throw new Uncoercible(type().name(), "LocalDateTime");
+        throw new Uncoercible(boltValueType().name(), "LocalDateTime");
     }
 
     @Override
     public ZonedDateTime asZonedDateTime() {
-        throw new Uncoercible(type().name(), "ZonedDateTime");
+        throw new Uncoercible(boltValueType().name(), "ZonedDateTime");
     }
 
     @Override
-    public IsoDuration asIsoDuration() {
-        throw new Uncoercible(type().name(), "Duration");
+    public IsoDuration asBoltIsoDuration() {
+        throw new Uncoercible(boltValueType().name(), "Duration");
     }
 
     @Override
-    public Point asPoint() {
-        throw new Uncoercible(type().name(), "Point");
+    public Point asBoltPoint() {
+        throw new Uncoercible(boltValueType().name(), "Point");
     }
 
     @Override
-    public Value get(String key) {
-        throw new NotMultiValued(type().name() + " is not a keyed collection");
+    public Value getBoltValue(String key) {
+        throw new NotMultiValued(boltValueType().name() + " is not a keyed collection");
     }
 
     @Override
     public int size() {
-        throw new Unsizable(type().name() + " does not have size");
+        throw new Unsizable(boltValueType().name() + " does not have size");
     }
 
     @Override
@@ -126,32 +125,32 @@ public abstract class ValueAdapter extends InternalMapAccessorWithDefaultValue i
 
     @Override
     public boolean isEmpty() {
-        return !values().iterator().hasNext();
+        return !boltValues().iterator().hasNext();
     }
 
     @Override
-    public Iterable<Value> values() {
-        throw new NotMultiValued(type().name() + " is not iterable");
+    public Iterable<Value> boltValues() {
+        throw new NotMultiValued(boltValueType().name() + " is not iterable");
     }
 
     @Override
     public byte[] asByteArray() {
-        throw new Uncoercible(type().name(), "byte[]");
+        throw new Uncoercible(boltValueType().name(), "byte[]");
     }
 
     @Override
     public TestNode asNode() {
-        throw new Uncoercible(type().name(), "Node");
+        throw new Uncoercible(boltValueType().name(), "Node");
     }
 
     @Override
     public TestRelationship asRelationship() {
-        throw new Uncoercible(type().name(), "Relationship");
+        throw new Uncoercible(boltValueType().name(), "Relationship");
     }
 
     @Override
     public TestPath asPath() {
-        throw new Uncoercible(type().name(), "Path");
+        throw new Uncoercible(boltValueType().name(), "Path");
     }
 
     // Force implementation

--- a/neo4j-bolt-connection/pom.xml
+++ b/neo4j-bolt-connection/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.neo4j.bolt</groupId>
         <artifactId>neo4j-bolt-connection-parent</artifactId>
-        <version>4.1-SNAPSHOT</version>
+        <version>5.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>neo4j-bolt-connection</artifactId>

--- a/neo4j-bolt-connection/src/main/java/org/neo4j/bolt/connection/BasicResponseHandler.java
+++ b/neo4j-bolt-connection/src/main/java/org/neo4j/bolt/connection/BasicResponseHandler.java
@@ -37,7 +37,7 @@ import org.neo4j.bolt.connection.values.Value;
 
 public final class BasicResponseHandler implements ResponseHandler {
     private final CompletableFuture<Summaries> summariesFuture = new CompletableFuture<>();
-    private final List<Value[]> valuesList = new ArrayList<>();
+    private final List<List<Value>> valuesList = new ArrayList<>();
 
     private BeginSummary beginSummary;
     private RunSummary runSummary;
@@ -85,7 +85,7 @@ public final class BasicResponseHandler implements ResponseHandler {
     }
 
     @Override
-    public void onRecord(Value[] fields) {
+    public void onRecord(List<Value> fields) {
         valuesList.add(fields);
     }
 
@@ -164,7 +164,7 @@ public final class BasicResponseHandler implements ResponseHandler {
     public record Summaries(
             BeginSummary beginSummary,
             RunSummary runSummary,
-            List<Value[]> valuesList,
+            List<List<Value>> valuesList,
             PullSummary pullSummary,
             DiscardSummary discardSummary,
             CommitSummary commitSummary,

--- a/neo4j-bolt-connection/src/main/java/org/neo4j/bolt/connection/ResponseHandler.java
+++ b/neo4j-bolt-connection/src/main/java/org/neo4j/bolt/connection/ResponseHandler.java
@@ -16,6 +16,7 @@
  */
 package org.neo4j.bolt.connection;
 
+import java.util.List;
 import org.neo4j.bolt.connection.summary.BeginSummary;
 import org.neo4j.bolt.connection.summary.CommitSummary;
 import org.neo4j.bolt.connection.summary.DiscardSummary;
@@ -41,7 +42,7 @@ public interface ResponseHandler {
         // ignored
     }
 
-    default void onRecord(Value[] fields) {
+    default void onRecord(List<Value> fields) {
         // ignored
     }
 

--- a/neo4j-bolt-connection/src/main/java/org/neo4j/bolt/connection/values/MapAccessor.java
+++ b/neo4j-bolt-connection/src/main/java/org/neo4j/bolt/connection/values/MapAccessor.java
@@ -16,19 +16,14 @@
  */
 package org.neo4j.bolt.connection.values;
 
-import java.util.Map;
-import java.util.function.Function;
-
 interface MapAccessor {
     Iterable<String> keys();
 
     int size();
 
-    Value get(String key);
+    Value getBoltValue(String key);
 
-    Iterable<Value> values();
+    Iterable<Value> boltValues();
 
     boolean containsKey(String key);
-
-    <T> Map<String, T> asMap(Function<Value, T> mapFunction);
 }

--- a/neo4j-bolt-connection/src/main/java/org/neo4j/bolt/connection/values/Value.java
+++ b/neo4j-bolt-connection/src/main/java/org/neo4j/bolt/connection/values/Value.java
@@ -21,9 +21,10 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.OffsetTime;
 import java.time.ZonedDateTime;
+import java.util.Map;
 
 public interface Value extends MapAccessor {
-    Type type();
+    Type boltValueType();
 
     boolean asBoolean();
 
@@ -45,9 +46,11 @@ public interface Value extends MapAccessor {
 
     ZonedDateTime asZonedDateTime();
 
-    IsoDuration asIsoDuration();
+    IsoDuration asBoltIsoDuration();
 
-    Point asPoint();
+    Point asBoltPoint();
+
+    Map<String, Value> asBoltMap();
 
     boolean isNull();
 

--- a/neo4j-bolt-connection/src/main/java/org/neo4j/bolt/connection/values/ValueFactory.java
+++ b/neo4j-bolt-connection/src/main/java/org/neo4j/bolt/connection/values/ValueFactory.java
@@ -56,7 +56,7 @@ public interface ValueFactory {
         return value((Object) stringToValue);
     }
 
-    default Value value(Value[] values) {
+    default Value value(List<Value> values) {
         return value((Object) values);
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.neo4j.bolt</groupId>
     <artifactId>neo4j-bolt-connection-parent</artifactId>
-    <version>4.1-SNAPSHOT</version>
+    <version>5.0-SNAPSHOT</version>
 
     <packaging>pom</packaging>
     <name>Neo4j Bolt Connection</name>


### PR DESCRIPTION
BREAKING CHANGE: Bolt List values are returned as `List<Value>` instead of `Value[]`, which affected mulple areas of the API. For example, `ResponseHandler#onRecord` and `asicResponseHandler.Summaries`. In addition, methods returning Bolt Connection API types in `MapAccessor` and `Value` have been renamed to include `bolt` word in their names, this helps with avoiding method clash with driver values when those choose to implement Bolt Connection `Value` directly. The `MapAccessor#asMap(Function)` method has been replaced with `Value#asBoltMap()`.