### PR TITLE
feat(acquisition): Add support for acquisition timeout to routed source

### DIFF
--- a/neo4j-bolt-connection-bom/pom.xml
+++ b/neo4j-bolt-connection-bom/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.neo4j.bolt</groupId>
         <artifactId>neo4j-bolt-connection-parent</artifactId>
-        <version>7.0-SNAPSHOT</version>
+        <version>8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>neo4j-bolt-connection-bom</artifactId>

--- a/neo4j-bolt-connection-netty/pom.xml
+++ b/neo4j-bolt-connection-netty/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.neo4j.bolt</groupId>
         <artifactId>neo4j-bolt-connection-parent</artifactId>
-        <version>7.0-SNAPSHOT</version>
+        <version>8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>neo4j-bolt-connection-netty</artifactId>
@@ -74,17 +74,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-failsafe-plugin</artifactId>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.apache.maven.surefire</groupId>
-                        <artifactId>surefire-junit-platform</artifactId>
-                        <version>${surefire.and.failsafe.version}</version>
-                    </dependency>
-                </dependencies>
             </plugin>
         </plugins>
     </build>

--- a/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/ConnectionProvider.java
+++ b/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/ConnectionProvider.java
@@ -37,6 +37,7 @@ public interface ConnectionProvider {
             BoltAgent boltAgent,
             String userAgent,
             int connectTimeoutMillis,
+            long initialisationTimeoutMillis,
             CompletableFuture<Long> latestAuthMillisFuture,
             NotificationConfig notificationConfig,
             ImmutableObservation parentObservation);

--- a/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/NettyBoltConnectionProvider.java
+++ b/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/NettyBoltConnectionProvider.java
@@ -92,6 +92,7 @@ public final class NettyBoltConnectionProvider implements BoltConnectionProvider
             BoltAgent boltAgent,
             String userAgent,
             int connectTimeoutMillis,
+            long initialisationTimeoutMillis,
             SecurityPlan securityPlan,
             AuthToken authToken,
             BoltProtocolVersion minVersion,
@@ -137,6 +138,7 @@ public final class NettyBoltConnectionProvider implements BoltConnectionProvider
                         boltAgent,
                         userAgent,
                         connectTimeoutMillis,
+                        initialisationTimeoutMillis,
                         latestAuthMillisFuture,
                         notificationConfig,
                         parentObservation)

--- a/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/async/connection/SslHandshakeDurationHandler.java
+++ b/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/async/connection/SslHandshakeDurationHandler.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.bolt.connection.netty.impl.async.connection;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.ChannelOption;
+import io.netty.handler.ssl.SslHandshakeCompletionEvent;
+import java.io.IOException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.concurrent.CompletableFuture;
+
+final class SslHandshakeDurationHandler extends ChannelInboundHandlerAdapter {
+    private final CompletableFuture<Duration> sslHandshakeFuture;
+    private Instant startInstant;
+
+    SslHandshakeDurationHandler(Channel channel, CompletableFuture<Duration> sslHandshakeFuture) {
+        this.sslHandshakeFuture = sslHandshakeFuture;
+        var fastOpen = Boolean.TRUE.equals(channel.config().getOption(ChannelOption.TCP_FASTOPEN_CONNECT));
+        if (fastOpen) {
+            startInstant = Instant.now();
+        }
+    }
+
+    @Override
+    public void channelActive(ChannelHandlerContext ctx) {
+        if (startInstant == null) {
+            startInstant = Instant.now();
+        }
+    }
+
+    @Override
+    public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+        if (evt instanceof SslHandshakeCompletionEvent event) {
+            if (event.isSuccess()) {
+                var duration = Duration.between(startInstant, Instant.now());
+                sslHandshakeFuture.complete(duration);
+            } else {
+                sslHandshakeFuture.completeExceptionally(event.cause());
+            }
+            ctx.pipeline().remove(this);
+        } else {
+            super.userEventTriggered(ctx, evt);
+        }
+    }
+
+    @Override
+    public void channelInactive(ChannelHandlerContext ctx) throws Exception {
+        if (!sslHandshakeFuture.isDone()) {
+            sslHandshakeFuture.completeExceptionally(
+                    new IOException("Inactive channel before SSL handshake is finished"));
+        }
+        super.channelInactive(ctx);
+    }
+}

--- a/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/async/inbound/ConnectTimeoutHandler.java
+++ b/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/async/inbound/ConnectTimeoutHandler.java
@@ -19,6 +19,7 @@ package org.neo4j.bolt.connection.netty.impl.async.inbound;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.timeout.ReadTimeoutHandler;
 import java.util.concurrent.TimeUnit;
+import org.neo4j.bolt.connection.exception.BoltConnectionInitialisationTimeoutException;
 import org.neo4j.bolt.connection.exception.BoltServiceUnavailableException;
 
 /**
@@ -27,12 +28,12 @@ import org.neo4j.bolt.connection.exception.BoltServiceUnavailableException;
  * Otherwise it will make long running queries fail.
  */
 public class ConnectTimeoutHandler extends ReadTimeoutHandler {
-    private final long timeoutMillis;
+    private final long overallTimeoutLimit;
     private boolean triggered;
 
-    public ConnectTimeoutHandler(long timeoutMillis) {
+    public ConnectTimeoutHandler(long timeoutMillis, long overallTimeoutLimit) {
         super(timeoutMillis, TimeUnit.MILLISECONDS);
-        this.timeoutMillis = timeoutMillis;
+        this.overallTimeoutLimit = overallTimeoutLimit;
     }
 
     @Override
@@ -44,6 +45,7 @@ public class ConnectTimeoutHandler extends ReadTimeoutHandler {
     }
 
     private BoltServiceUnavailableException unableToConnectError() {
-        return new BoltServiceUnavailableException("Unable to establish connection in " + timeoutMillis + "ms");
+        return new BoltConnectionInitialisationTimeoutException(
+                "Unable to initialise connection in " + overallTimeoutLimit + "ms");
     }
 }

--- a/neo4j-bolt-connection-netty/src/test/java/org/neo4j/bolt/connection/netty/impl/NettyBoltConnectionProviderIT.java
+++ b/neo4j-bolt-connection-netty/src/test/java/org/neo4j/bolt/connection/netty/impl/NettyBoltConnectionProviderIT.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.bolt.connection.netty.impl;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import io.netty.handler.ssl.SslHandshakeTimeoutException;
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.net.URI;
+import java.security.GeneralSecurityException;
+import java.util.Map;
+import java.util.concurrent.CompletionException;
+import java.util.function.BiConsumer;
+import java.util.function.Supplier;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.neo4j.bolt.connection.AuthToken;
+import org.neo4j.bolt.connection.AuthTokens;
+import org.neo4j.bolt.connection.BoltAgent;
+import org.neo4j.bolt.connection.BoltConnectionProvider;
+import org.neo4j.bolt.connection.BoltProtocolVersion;
+import org.neo4j.bolt.connection.LoggingProvider;
+import org.neo4j.bolt.connection.SecurityPlans;
+import org.neo4j.bolt.connection.exception.BoltConnectionInitialisationTimeoutException;
+import org.neo4j.bolt.connection.netty.NettyBoltConnectionProviderFactory;
+import org.neo4j.bolt.connection.observation.BoltExchangeObservation;
+import org.neo4j.bolt.connection.observation.HttpExchangeObservation;
+import org.neo4j.bolt.connection.observation.ImmutableObservation;
+import org.neo4j.bolt.connection.observation.ObservationProvider;
+import org.neo4j.bolt.connection.test.values.TestValueFactory;
+import org.neo4j.bolt.connection.values.ValueFactory;
+
+class NettyBoltConnectionProviderIT {
+    static NettyBoltConnectionProviderFactory factory = new NettyBoltConnectionProviderFactory();
+    static LoggingProvider loggingProvider = new SystemLoggingProvider();
+    static ValueFactory valueFactory = TestValueFactory.INSTANCE;
+    static ObservationProvider observationProvider = new NoopObservationProvider();
+    static BoltAgent boltAgent = new BoltAgent("product", "platform", "language", "languageDetails");
+    static String userAgent = "userAgent";
+    static AuthToken authToken = AuthTokens.none(valueFactory);
+
+    BoltConnectionProvider provider;
+
+    @BeforeEach
+    void beforeEach() {
+        provider = factory.create(loggingProvider, valueFactory, observationProvider, Map.of());
+    }
+
+    @Test
+    void shouldTimeoutSslHandshake() throws GeneralSecurityException, IOException {
+        try (var server = new ServerSocket(0)) {
+            // given
+            var uri = URI.create("bolt://localhost:%d".formatted(server.getLocalPort()));
+
+            // when
+            var connectionFuture = provider.connect(
+                            uri,
+                            null,
+                            boltAgent,
+                            userAgent,
+                            0,
+                            100,
+                            SecurityPlans.encryptedForAnyCertificate(),
+                            authToken,
+                            null,
+                            null,
+                            NoopObservationProvider.NOOP_OBSERVATION)
+                    .toCompletableFuture();
+
+            // then
+            Throwable exception = assertThrows(CompletionException.class, connectionFuture::join);
+            exception = exception.getCause();
+            assertInstanceOf(BoltConnectionInitialisationTimeoutException.class, exception);
+            exception = exception.getCause();
+            assertInstanceOf(SslHandshakeTimeoutException.class, exception);
+        }
+    }
+
+    static class SystemLoggingProvider implements LoggingProvider {
+        @Override
+        public System.Logger getLog(Class<?> cls) {
+            return System.getLogger(cls.getName());
+        }
+
+        @Override
+        public System.Logger getLog(String name) {
+            return System.getLogger(name);
+        }
+    }
+
+    static class NoopObservationProvider implements ObservationProvider {
+        static final NoopObservation NOOP_OBSERVATION = new NoopObservation();
+
+        @Override
+        public BoltExchangeObservation boltExchange(
+                ImmutableObservation observationParent,
+                String host,
+                int port,
+                BoltProtocolVersion boltVersion,
+                BiConsumer<String, String> setter) {
+            return NOOP_OBSERVATION;
+        }
+
+        @Override
+        public HttpExchangeObservation httpExchange(
+                ImmutableObservation observationParent,
+                URI uri,
+                String method,
+                String uriTemplate,
+                BiConsumer<String, String> setter) {
+            return null;
+        }
+
+        @Override
+        public ImmutableObservation scopedObservation() {
+            return null;
+        }
+
+        @Override
+        public <T> T supplyInScope(ImmutableObservation observation, Supplier<T> supplier) {
+            return supplier.get();
+        }
+    }
+
+    static class NoopObservation implements BoltExchangeObservation {
+        @Override
+        public BoltExchangeObservation onWrite(String messageName) {
+            return this;
+        }
+
+        @Override
+        public BoltExchangeObservation onRecord() {
+            return this;
+        }
+
+        @Override
+        public BoltExchangeObservation onSummary(String messageName) {
+            return this;
+        }
+
+        @Override
+        public BoltExchangeObservation error(Throwable error) {
+            return this;
+        }
+
+        @Override
+        public void stop() {}
+    }
+}

--- a/neo4j-bolt-connection-netty/src/test/java/org/neo4j/bolt/connection/netty/impl/async/connection/ChannelConnectedListenerTest.java
+++ b/neo4j-bolt-connection-netty/src/test/java/org/neo4j/bolt/connection/netty/impl/async/connection/ChannelConnectedListenerTest.java
@@ -32,6 +32,7 @@ import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.GenericFutureListener;
 import java.io.IOException;
+import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.TimeUnit;
@@ -116,7 +117,9 @@ class ChannelConnectedListenerTest {
                 handshakeCompletedFuture,
                 null,
                 NoopLoggingProvider.INSTANCE,
-                mock(ValueFactory.class));
+                mock(ValueFactory.class),
+                0,
+                CompletableFuture.completedFuture(Duration.ZERO));
     }
 
     private record FailedPromise(Throwable failure) implements ChannelPromise {

--- a/neo4j-bolt-connection-netty/src/test/java/org/neo4j/bolt/connection/netty/impl/async/connection/NettyChannelInitializerTest.java
+++ b/neo4j-bolt-connection-netty/src/test/java/org/neo4j/bolt/connection/netty/impl/async/connection/NettyChannelInitializerTest.java
@@ -34,6 +34,7 @@ import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.time.Clock;
+import java.util.concurrent.CompletableFuture;
 import javax.net.ssl.KeyManager;
 import javax.net.ssl.SNIHostName;
 import javax.net.ssl.SSLContext;
@@ -103,7 +104,12 @@ class NettyChannelInitializerTest {
     void shouldIncludeSniHostName() {
         var address = new BoltServerAddress("database.neo4j.com", 8989);
         var initializer = new NettyChannelInitializer(
-                address, trustAllCertificates(false), 10000, Clock.systemUTC(), NoopLoggingProvider.INSTANCE);
+                address,
+                trustAllCertificates(false),
+                10000,
+                Clock.systemUTC(),
+                NoopLoggingProvider.INSTANCE,
+                new CompletableFuture<>());
 
         initializer.initChannel(channel);
 
@@ -148,7 +154,12 @@ class NettyChannelInitializerTest {
     private static NettyChannelInitializer newInitializer(
             SecurityPlan securityPlan, int connectTimeoutMillis, Clock clock) {
         return new NettyChannelInitializer(
-                LOCAL_DEFAULT, securityPlan, connectTimeoutMillis, clock, NoopLoggingProvider.INSTANCE);
+                LOCAL_DEFAULT,
+                securityPlan,
+                connectTimeoutMillis,
+                clock,
+                NoopLoggingProvider.INSTANCE,
+                new CompletableFuture<>());
     }
 
     private static SecurityPlan trustAllCertificates(boolean enabled) {

--- a/neo4j-bolt-connection-netty/src/test/java/org/neo4j/bolt/connection/netty/impl/async/inbound/ConnectTimeoutHandlerTest.java
+++ b/neo4j-bolt-connection-netty/src/test/java/org/neo4j/bolt/connection/netty/impl/async/inbound/ConnectTimeoutHandlerTest.java
@@ -22,7 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import io.netty.channel.embedded.EmbeddedChannel;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
-import org.neo4j.bolt.connection.exception.BoltServiceUnavailableException;
+import org.neo4j.bolt.connection.exception.BoltConnectionInitialisationTimeoutException;
 
 class ConnectTimeoutHandlerTest {
     private final EmbeddedChannel channel = new EmbeddedChannel();
@@ -35,27 +35,27 @@ class ConnectTimeoutHandlerTest {
     @Test
     void shouldFireExceptionOnTimeout() throws Exception {
         var timeoutMillis = 100;
-        channel.pipeline().addLast(new ConnectTimeoutHandler(timeoutMillis));
+        channel.pipeline().addLast(new ConnectTimeoutHandler(timeoutMillis, timeoutMillis));
 
         // sleep for more than the timeout value
         Thread.sleep(timeoutMillis * 4);
         channel.runPendingTasks();
 
-        var error = assertThrows(BoltServiceUnavailableException.class, channel::checkException);
-        assertEquals(error.getMessage(), "Unable to establish connection in " + timeoutMillis + "ms");
+        var error = assertThrows(BoltConnectionInitialisationTimeoutException.class, channel::checkException);
+        assertEquals(error.getMessage(), "Unable to initialise connection in " + timeoutMillis + "ms");
     }
 
     @Test
     void shouldNotFireExceptionMultipleTimes() throws Exception {
         var timeoutMillis = 70;
-        channel.pipeline().addLast(new ConnectTimeoutHandler(timeoutMillis));
+        channel.pipeline().addLast(new ConnectTimeoutHandler(timeoutMillis, timeoutMillis));
 
         // sleep for more than the timeout value
         Thread.sleep(timeoutMillis * 4);
         channel.runPendingTasks();
 
-        var error = assertThrows(BoltServiceUnavailableException.class, channel::checkException);
-        assertEquals(error.getMessage(), "Unable to establish connection in " + timeoutMillis + "ms");
+        var error = assertThrows(BoltConnectionInitialisationTimeoutException.class, channel::checkException);
+        assertEquals(error.getMessage(), "Unable to initialise connection in " + timeoutMillis + "ms");
 
         // sleep even more
         Thread.sleep(timeoutMillis * 4);

--- a/neo4j-bolt-connection-pooled/pom.xml
+++ b/neo4j-bolt-connection-pooled/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.neo4j.bolt</groupId>
         <artifactId>neo4j-bolt-connection-parent</artifactId>
-        <version>7.0-SNAPSHOT</version>
+        <version>8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>neo4j-bolt-connection-pooled</artifactId>

--- a/neo4j-bolt-connection-query-api/pom.xml
+++ b/neo4j-bolt-connection-query-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.neo4j.bolt</groupId>
         <artifactId>neo4j-bolt-connection-parent</artifactId>
-        <version>7.0-SNAPSHOT</version>
+        <version>8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>neo4j-bolt-connection-query-api</artifactId>

--- a/neo4j-bolt-connection-query-api/src/main/java/org/neo4j/bolt/connection/query_api/impl/QueryApiBoltConnectionProvider.java
+++ b/neo4j-bolt-connection-query-api/src/main/java/org/neo4j/bolt/connection/query_api/impl/QueryApiBoltConnectionProvider.java
@@ -72,6 +72,7 @@ public class QueryApiBoltConnectionProvider implements BoltConnectionProvider {
             BoltAgent boltAgent,
             String userAgent,
             int connectTimeoutMillis,
+            long initialisationTimeoutMillis,
             SecurityPlan securityPlan,
             AuthToken authToken,
             BoltProtocolVersion minVersion,

--- a/neo4j-bolt-connection-query-api/src/test/java/org/neo4j/bolt/connection/query_api/impl/AbstractQueryApi.java
+++ b/neo4j-bolt-connection-query-api/src/test/java/org/neo4j/bolt/connection/query_api/impl/AbstractQueryApi.java
@@ -104,6 +104,7 @@ abstract class AbstractQueryApi {
                         null,
                         null,
                         0,
+                        0,
                         SecurityPlans.encryptedForSystemCASignedCertificates(),
                         AuthTokens.basic(username(), password(), "basic", valueFactory),
                         null,

--- a/neo4j-bolt-connection-routed/pom.xml
+++ b/neo4j-bolt-connection-routed/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.neo4j.bolt</groupId>
         <artifactId>neo4j-bolt-connection-parent</artifactId>
-        <version>7.0-SNAPSHOT</version>
+        <version>8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>neo4j-bolt-connection-routed</artifactId>

--- a/neo4j-bolt-connection-routed/src/test/java/org/neo4j/bolt/connection/routed/RoutedBoltConnectionSourceTest.java
+++ b/neo4j-bolt-connection-routed/src/test/java/org/neo4j/bolt/connection/routed/RoutedBoltConnectionSourceTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.bolt.connection.routed;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.MockitoAnnotations.openMocks;
+
+import java.net.URI;
+import java.time.Clock;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.TimeoutException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.neo4j.bolt.connection.BoltConnectionParameters;
+import org.neo4j.bolt.connection.BoltConnectionSource;
+import org.neo4j.bolt.connection.DefaultDomainNameResolver;
+import org.neo4j.bolt.connection.LoggingProvider;
+import org.neo4j.bolt.connection.observation.ObservationProvider;
+
+class RoutedBoltConnectionSourceTest {
+    RoutedBoltConnectionSource source;
+
+    @Mock
+    BoltConnectionSourceFactory boltConnectionSourceFactory;
+
+    @Mock
+    BoltConnectionSource<BoltConnectionParameters> upstream;
+
+    @Mock
+    ObservationProvider observationProvider;
+
+    @Mock
+    LoggingProvider loggingProvider;
+
+    @BeforeEach
+    void beforeEach() {
+        openMocks(this);
+    }
+
+    @Test
+    void shouldTimeout() {
+        // given
+        given(boltConnectionSourceFactory.create(any(), any())).willReturn(upstream);
+        given(upstream.getConnection(any())).willReturn(new CompletableFuture<>());
+        source = new RoutedBoltConnectionSource(
+                boltConnectionSourceFactory,
+                Set::of,
+                DefaultDomainNameResolver.getInstance(),
+                1000,
+                null,
+                Clock.systemUTC(),
+                loggingProvider,
+                URI.create("neo4j://localhost:7687"),
+                1,
+                List.of(),
+                observationProvider);
+
+        // when
+        var connectionStage = source.getConnection();
+
+        // then
+        var completionException = assertThrows(
+                CompletionException.class,
+                () -> connectionStage.toCompletableFuture().join());
+        assertInstanceOf(TimeoutException.class, completionException.getCause());
+    }
+}

--- a/neo4j-bolt-connection-test-values/pom.xml
+++ b/neo4j-bolt-connection-test-values/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.neo4j.bolt</groupId>
         <artifactId>neo4j-bolt-connection-parent</artifactId>
-        <version>7.0-SNAPSHOT</version>
+        <version>8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>neo4j-bolt-connection-test-values</artifactId>

--- a/neo4j-bolt-connection/pom.xml
+++ b/neo4j-bolt-connection/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.neo4j.bolt</groupId>
         <artifactId>neo4j-bolt-connection-parent</artifactId>
-        <version>7.0-SNAPSHOT</version>
+        <version>8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>neo4j-bolt-connection</artifactId>

--- a/neo4j-bolt-connection/src/main/java/org/neo4j/bolt/connection/BoltConnectionProvider.java
+++ b/neo4j-bolt-connection/src/main/java/org/neo4j/bolt/connection/BoltConnectionProvider.java
@@ -34,19 +34,20 @@ public interface BoltConnectionProvider {
     /**
      * Connects to the given {@link URI} using the provided parameters and returns {@link BoltConnection} instance.
      *
-     * @param uri                   the connection {@link URI}
-     * @param routingContextAddress the address to be used in the 'address' field of routing context. This applies to
-     *                              URI schemes that support routing context only. When set to {@code null}, the default
-     *                              behaviour of getting the address from the URI applies. This parameter should be used
-     *                              when an explicit address that differs from the one in the URI should be used.
-     * @param boltAgent             the {@link BoltAgent}
-     * @param userAgent             the User Agent
-     * @param connectTimeoutMillis  the connection timeout
-     * @param securityPlan          the {@link SecurityPlan}
-     * @param authToken             the {@link AuthToken}
-     * @param minVersion            the minimum {@link BoltProtocolVersion}
-     * @param notificationConfig    the {@link NotificationConfig}, this usually used in the Bolt {@code HELLO} message
-     * @param parentObservation     the parent {@link ImmutableObservation} that should be used as a parent for nested observations
+     * @param uri                         the connection {@link URI}
+     * @param routingContextAddress       the address to be used in the 'address' field of routing context. This applies to
+     *                                    URI schemes that support routing context only. When set to {@code null}, the default
+     *                                    behaviour of getting the address from the URI applies. This parameter should be used
+     *                                    when an explicit address that differs from the one in the URI should be used.
+     * @param boltAgent                   the {@link BoltAgent}
+     * @param userAgent                   the User Agent
+     * @param connectTimeoutMillis        the connection timeout, {@literal 0} or negative disables timeout
+     * @param initialisationTimeoutMillis the connection initialisation timeout, includes SSL and Bolt Handshake, {@literal 0} or negative disables timeout
+     * @param securityPlan                the {@link SecurityPlan}
+     * @param authToken                   the {@link AuthToken}
+     * @param minVersion                  the minimum {@link BoltProtocolVersion}
+     * @param notificationConfig          the {@link NotificationConfig}, this usually used in the Bolt {@code HELLO} message
+     * @param parentObservation           the parent {@link ImmutableObservation} that should be used as a parent for nested observations
      * @return the {@link BoltConnection} instance
      */
     CompletionStage<BoltConnection> connect(
@@ -55,6 +56,7 @@ public interface BoltConnectionProvider {
             BoltAgent boltAgent,
             String userAgent,
             int connectTimeoutMillis,
+            long initialisationTimeoutMillis,
             SecurityPlan securityPlan,
             AuthToken authToken,
             BoltProtocolVersion minVersion,

--- a/neo4j-bolt-connection/src/main/java/org/neo4j/bolt/connection/exception/BoltConnectionInitialisationTimeoutException.java
+++ b/neo4j-bolt-connection/src/main/java/org/neo4j/bolt/connection/exception/BoltConnectionInitialisationTimeoutException.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.bolt.connection.exception;
+
+import java.io.Serial;
+
+public final class BoltConnectionInitialisationTimeoutException extends BoltServiceUnavailableException {
+    @Serial
+    private static final long serialVersionUID = -5223764236504718952L;
+
+    public BoltConnectionInitialisationTimeoutException(String message) {
+        super(message);
+    }
+
+    public BoltConnectionInitialisationTimeoutException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.neo4j.bolt</groupId>
     <artifactId>neo4j-bolt-connection-parent</artifactId>
-    <version>7.0-SNAPSHOT</version>
+    <version>8.0-SNAPSHOT</version>
 
     <packaging>pom</packaging>
     <name>Neo4j Bolt Connection</name>
@@ -47,16 +47,16 @@
     <properties>
         <bouncycastle-jdk18on.version>1.81</bouncycastle-jdk18on.version>
         <build-resources.version>2024-12.1</build-resources.version>
-        <junit.version>5.13.2</junit.version>
+        <junit.version>6.0.0-RC2</junit.version>
         <maven.build.timestamp.format>'v'yyyyMMdd-HHmm</maven.build.timestamp.format>
         <maven.compiler.release>17</maven.compiler.release>
         <maven.compiler.xlint.extras />
         <!-- Skip deployment by default for everything in this project. -->
         <maven.deploy.skip>true</maven.deploy.skip>
-        <mockito.version>5.18.0</mockito.version>
+        <mockito.version>5.19.0</mockito.version>
         <!-- To be overwritten by child projects -->
         <moduleName />
-        <netty-bom.version>4.2.2.Final</netty-bom.version>
+        <netty-bom.version>4.2.4.Final</netty-bom.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <rootDir>${project.basedir}</rootDir>


### PR DESCRIPTION
BREAKING CHANGE: new parameters have been added to `RoutedBoltConnectionSource`, `PooledBoltConnectionSource` and `BoltConnectionProvider`.

The latter had to be updated to separate connection timeout from initialisation timeout. Previously, connection timeout was simply used 2 times to cover both and could lead to confusion.