### PR TITLE
feat(unix): add support for bolt+unix

### DIFF
--- a/neo4j-bolt-connection-bom/pom.xml
+++ b/neo4j-bolt-connection-bom/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.neo4j.bolt</groupId>
         <artifactId>neo4j-bolt-connection-parent</artifactId>
-        <version>8.3-SNAPSHOT</version>
+        <version>8.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>neo4j-bolt-connection-bom</artifactId>

--- a/neo4j-bolt-connection-netty/pom.xml
+++ b/neo4j-bolt-connection-netty/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.neo4j.bolt</groupId>
         <artifactId>neo4j-bolt-connection-parent</artifactId>
-        <version>8.3-SNAPSHOT</version>
+        <version>8.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>neo4j-bolt-connection-netty</artifactId>

--- a/neo4j-bolt-connection-netty/src/main/java/module-info.java
+++ b/neo4j-bolt-connection-netty/src/main/java/module-info.java
@@ -34,4 +34,5 @@ module org.neo4j.bolt.connection.netty {
     requires static io.netty.transport.classes.epoll;
     requires static io.netty.transport.classes.io_uring;
     requires static io.netty.transport.classes.kqueue;
+    requires static io.netty.transport.unix.common;
 }

--- a/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/ConnectionProvider.java
+++ b/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/ConnectionProvider.java
@@ -16,11 +16,11 @@
  */
 package org.neo4j.bolt.connection.netty.impl;
 
+import java.net.URI;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import org.neo4j.bolt.connection.BoltAgent;
-import org.neo4j.bolt.connection.BoltServerAddress;
 import org.neo4j.bolt.connection.NotificationConfig;
 import org.neo4j.bolt.connection.SecurityPlan;
 import org.neo4j.bolt.connection.netty.impl.spi.Connection;
@@ -30,7 +30,7 @@ import org.neo4j.bolt.connection.values.Value;
 public interface ConnectionProvider {
 
     CompletionStage<Connection> acquireConnection(
-            BoltServerAddress address,
+            URI uri,
             SecurityPlan securityPlan,
             RoutingContext routingContext,
             Map<String, Value> authMap,

--- a/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/ConnectionProviders.java
+++ b/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/ConnectionProviders.java
@@ -16,20 +16,20 @@
  */
 package org.neo4j.bolt.connection.netty.impl;
 
-import io.netty.channel.Channel;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.local.LocalAddress;
 import java.time.Clock;
 import org.neo4j.bolt.connection.BoltProtocolVersion;
 import org.neo4j.bolt.connection.DomainNameResolver;
 import org.neo4j.bolt.connection.LoggingProvider;
+import org.neo4j.bolt.connection.netty.impl.async.connection.NettyTransport;
 import org.neo4j.bolt.connection.observation.ObservationProvider;
 import org.neo4j.bolt.connection.values.ValueFactory;
 
 public class ConnectionProviders {
     public static ConnectionProvider netty(
             EventLoopGroup group,
-            Class<? extends Channel> channelClass,
+            NettyTransport nettyTransport,
             Clock clock,
             DomainNameResolver domainNameResolver,
             LocalAddress localAddress,
@@ -41,7 +41,7 @@ public class ConnectionProviders {
             ObservationProvider observationProvider) {
         return new NettyConnectionProvider(
                 group,
-                channelClass,
+                nettyTransport,
                 clock,
                 domainNameResolver,
                 localAddress,

--- a/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/Scheme.java
+++ b/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/Scheme.java
@@ -18,10 +18,11 @@ package org.neo4j.bolt.connection.netty.impl;
 
 import java.util.List;
 
-class Scheme {
+public class Scheme {
     public static final String NEO4J_URI_SCHEME = "neo4j";
     public static final String NEO4J_HIGH_TRUST_URI_SCHEME = "neo4j+s";
     public static final String NEO4J_LOW_TRUST_URI_SCHEME = "neo4j+ssc";
+    public static final String BOLT_UNIX_SCHEME = "bolt+unix";
 
     static boolean isRoutingScheme(String scheme) {
         return List.of(NEO4J_LOW_TRUST_URI_SCHEME, NEO4J_HIGH_TRUST_URI_SCHEME, NEO4J_URI_SCHEME)

--- a/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/async/connection/ChannelConnectedListener.java
+++ b/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/async/connection/ChannelConnectedListener.java
@@ -122,7 +122,6 @@ public class ChannelConnectedListener implements ChannelFutureListener {
                         pipeline.addLast(new HandshakeHandler(
                                 pipelineBuilder,
                                 handshakeCompletedFuture,
-                                address,
                                 maxVersion,
                                 false,
                                 initialisationTimeoutMillis,

--- a/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/async/connection/EventLoopGroupFactory.java
+++ b/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/async/connection/EventLoopGroupFactory.java
@@ -16,7 +16,6 @@
  */
 package org.neo4j.bolt.connection.netty.impl.async.connection;
 
-import io.netty.channel.Channel;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.MultiThreadIoEventLoopGroup;
 import io.netty.channel.epoll.EpollEventLoopGroup;
@@ -47,12 +46,8 @@ public final class EventLoopGroupFactory {
         this.nettyTransport = Objects.requireNonNull(nettyTransport);
     }
 
-    public Class<? extends Channel> channelClass() {
-        return nettyTransport.channelClass();
-    }
-
-    public boolean fastOpenAvailable() {
-        return nettyTransport.fastOpenAvailable();
+    public NettyTransport nettyTransport() {
+        return nettyTransport;
     }
 
     @SuppressWarnings("deprecation")

--- a/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/async/connection/HandshakeHandler.java
+++ b/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/async/connection/HandshakeHandler.java
@@ -29,7 +29,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import javax.net.ssl.SSLHandshakeException;
 import org.neo4j.bolt.connection.BoltProtocolVersion;
-import org.neo4j.bolt.connection.BoltServerAddress;
 import org.neo4j.bolt.connection.LoggingProvider;
 import org.neo4j.bolt.connection.exception.BoltClientException;
 import org.neo4j.bolt.connection.exception.BoltConnectionInitialisationTimeoutException;
@@ -45,7 +44,6 @@ public class HandshakeHandler extends ReplayingDecoder<Void> {
     private final CompletableFuture<Channel> handshakeCompletedFuture;
     private final LoggingProvider logging;
     private final ValueFactory valueFactory;
-    private final BoltServerAddress address;
     private final BoltProtocolVersion maxVersion;
     private final boolean fastOpen;
     private final long initialisationTimeoutMillis;
@@ -59,7 +57,6 @@ public class HandshakeHandler extends ReplayingDecoder<Void> {
     public HandshakeHandler(
             ChannelPipelineBuilder pipelineBuilder,
             CompletableFuture<Channel> handshakeCompletedFuture,
-            BoltServerAddress address,
             BoltProtocolVersion maxVersion,
             boolean fastOpen,
             long initialisationTimeoutMillis,
@@ -68,7 +65,6 @@ public class HandshakeHandler extends ReplayingDecoder<Void> {
             ValueFactory valueFactory) {
         this.pipelineBuilder = pipelineBuilder;
         this.handshakeCompletedFuture = handshakeCompletedFuture;
-        this.address = Objects.requireNonNull(address);
         this.maxVersion = maxVersion;
         this.fastOpen = fastOpen;
         this.initialisationTimeoutMillis = initialisationTimeoutMillis;

--- a/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/async/connection/NettyChannelInitializer.java
+++ b/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/async/connection/NettyChannelInitializer.java
@@ -80,7 +80,6 @@ public class NettyChannelInitializer extends ChannelInitializer<Channel> {
                 var handshakeHandler = new HandshakeHandler(
                         new ChannelPipelineBuilderImpl(),
                         handshakeCompleted,
-                        address,
                         maxVersion,
                         true,
                         sslHandshakeTimeoutMillis,

--- a/neo4j-bolt-connection-netty/src/test/java/org/neo4j/bolt/connection/netty/impl/async/connection/EventLoopGroupFactoryTest.java
+++ b/neo4j-bolt-connection-netty/src/test/java/org/neo4j/bolt/connection/netty/impl/async/connection/EventLoopGroupFactoryTest.java
@@ -25,7 +25,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.nio.NioEventLoopGroup;
-import io.netty.channel.socket.nio.NioSocketChannel;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.StreamSupport;
 import org.junit.jupiter.api.AfterEach;
@@ -41,8 +40,9 @@ class EventLoopGroupFactoryTest {
     }
 
     @Test
-    void shouldReturnCorrectChannelClass() {
-        assertEquals(NioSocketChannel.class, eventLoopGroupFactory.channelClass());
+    void shouldReturnNettyTransport() {
+        assertEquals(
+                NettyTransport.Type.NIO, eventLoopGroupFactory.nettyTransport().type());
     }
 
     // use NioEventLoopGroup for now to be compatible with Netty 4.1

--- a/neo4j-bolt-connection-netty/src/test/java/org/neo4j/bolt/connection/netty/impl/async/connection/HandshakeHandlerTest.java
+++ b/neo4j-bolt-connection-netty/src/test/java/org/neo4j/bolt/connection/netty/impl/async/connection/HandshakeHandlerTest.java
@@ -44,7 +44,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.neo4j.bolt.connection.BoltProtocolVersion;
-import org.neo4j.bolt.connection.BoltServerAddress;
 import org.neo4j.bolt.connection.LoggingProvider;
 import org.neo4j.bolt.connection.exception.BoltClientException;
 import org.neo4j.bolt.connection.exception.BoltServiceUnavailableException;
@@ -304,7 +303,6 @@ class HandshakeHandlerTest {
         return new HandshakeHandler(
                 pipelineBuilder,
                 handshakeCompletedPromise,
-                new BoltServerAddress("127.0.0.1", 7687),
                 null,
                 false,
                 0,

--- a/neo4j-bolt-connection-pooled/pom.xml
+++ b/neo4j-bolt-connection-pooled/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.neo4j.bolt</groupId>
         <artifactId>neo4j-bolt-connection-parent</artifactId>
-        <version>8.3-SNAPSHOT</version>
+        <version>8.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>neo4j-bolt-connection-pooled</artifactId>

--- a/neo4j-bolt-connection-pooled/src/main/java/org/neo4j/bolt/connection/pooled/PooledBoltConnectionSource.java
+++ b/neo4j-bolt-connection-pooled/src/main/java/org/neo4j/bolt/connection/pooled/PooledBoltConnectionSource.java
@@ -17,6 +17,7 @@
 package org.neo4j.bolt.connection.pooled;
 
 import java.net.URI;
+import java.nio.file.Path;
 import java.time.Clock;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -107,6 +108,7 @@ public class PooledBoltConnectionSource implements BoltConnectionSource<BoltConn
         this.uri = Objects.requireNonNull(uri);
         this.address = switch (uri.getScheme()) {
             case "bolt", "bolt+s", "bolt+ssc", "neo4j", "neo4j+s", "neo4j+ssc" -> new BoltServerAddress(uri);
+            case "bolt+unix" -> new BoltServerAddress(Path.of(uri.getPath()));
             default -> new BoltServerAddress(uri.getHost(), 0);};
         this.poolId = poolId(address);
         this.observationProvider = Objects.requireNonNull(observationProvider);
@@ -567,7 +569,7 @@ public class PooledBoltConnectionSource implements BoltConnectionSource<BoltConn
     }
 
     private String poolId(BoltServerAddress serverAddress) {
-        return serverAddress.port() == 0
+        return serverAddress.port() <= 0
                 ? String.format("%s-%d", serverAddress.host(), this.hashCode())
                 : String.format("%s:%d-%d", serverAddress.host(), serverAddress.port(), this.hashCode());
     }

--- a/neo4j-bolt-connection-query-api/pom.xml
+++ b/neo4j-bolt-connection-query-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.neo4j.bolt</groupId>
         <artifactId>neo4j-bolt-connection-parent</artifactId>
-        <version>8.3-SNAPSHOT</version>
+        <version>8.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>neo4j-bolt-connection-query-api</artifactId>

--- a/neo4j-bolt-connection-routed/pom.xml
+++ b/neo4j-bolt-connection-routed/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.neo4j.bolt</groupId>
         <artifactId>neo4j-bolt-connection-parent</artifactId>
-        <version>8.3-SNAPSHOT</version>
+        <version>8.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>neo4j-bolt-connection-routed</artifactId>

--- a/neo4j-bolt-connection-test-values/pom.xml
+++ b/neo4j-bolt-connection-test-values/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.neo4j.bolt</groupId>
         <artifactId>neo4j-bolt-connection-parent</artifactId>
-        <version>8.3-SNAPSHOT</version>
+        <version>8.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>neo4j-bolt-connection-test-values</artifactId>

--- a/neo4j-bolt-connection/pom.xml
+++ b/neo4j-bolt-connection/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.neo4j.bolt</groupId>
         <artifactId>neo4j-bolt-connection-parent</artifactId>
-        <version>8.3-SNAPSHOT</version>
+        <version>8.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>neo4j-bolt-connection</artifactId>

--- a/neo4j-bolt-connection/src/main/java/org/neo4j/bolt/connection/BoltServerAddress.java
+++ b/neo4j-bolt-connection/src/main/java/org/neo4j/bolt/connection/BoltServerAddress.java
@@ -19,6 +19,7 @@ package org.neo4j.bolt.connection;
 import static java.util.Objects.requireNonNull;
 
 import java.net.URI;
+import java.nio.file.Path;
 import java.util.Objects;
 import java.util.stream.Stream;
 
@@ -35,6 +36,7 @@ public class BoltServerAddress {
     // resolved IP address.
     protected final int port;
     private final String stringValue;
+    private final Path path;
 
     public BoltServerAddress(String address) {
         this(uriFrom(address));
@@ -55,6 +57,15 @@ public class BoltServerAddress {
         this.stringValue = host.equals(connectionHost)
                 ? String.format("%s:%d", host, port)
                 : String.format("%s(%s):%d", host, connectionHost, port);
+        this.path = null;
+    }
+
+    public BoltServerAddress(Path path) {
+        this.host = path.toString();
+        this.connectionHost = this.host;
+        this.port = -1;
+        this.stringValue = this.host;
+        this.path = path;
     }
 
     @Override
@@ -89,6 +100,10 @@ public class BoltServerAddress {
 
     public String connectionHost() {
         return connectionHost;
+    }
+
+    public Path path() {
+        return path;
     }
 
     /**

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.neo4j.bolt</groupId>
     <artifactId>neo4j-bolt-connection-parent</artifactId>
-    <version>8.3-SNAPSHOT</version>
+    <version>8.4-SNAPSHOT</version>
 
     <packaging>pom</packaging>
     <name>Neo4j Bolt Connection</name>


### PR DESCRIPTION
This update adds support for `bolt+unix` scheme to `neo4j-bolt-connection-netty` module.