### PR TITLE
feat(pooled): Do not close upstream BoltConnectionProvider

### DIFF
--- a/neo4j-bolt-connection-bom/pom.xml
+++ b/neo4j-bolt-connection-bom/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.neo4j.bolt</groupId>
         <artifactId>neo4j-bolt-connection-parent</artifactId>
-        <version>10.1-SNAPSHOT</version>
+        <version>11.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>neo4j-bolt-connection-bom</artifactId>

--- a/neo4j-bolt-connection-netty/pom.xml
+++ b/neo4j-bolt-connection-netty/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.neo4j.bolt</groupId>
         <artifactId>neo4j-bolt-connection-parent</artifactId>
-        <version>10.1-SNAPSHOT</version>
+        <version>11.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>neo4j-bolt-connection-netty</artifactId>

--- a/neo4j-bolt-connection-pooled/pom.xml
+++ b/neo4j-bolt-connection-pooled/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.neo4j.bolt</groupId>
         <artifactId>neo4j-bolt-connection-parent</artifactId>
-        <version>10.1-SNAPSHOT</version>
+        <version>11.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>neo4j-bolt-connection-pooled</artifactId>

--- a/neo4j-bolt-connection-pooled/src/main/java/org/neo4j/bolt/connection/pooled/PooledBoltConnectionSource.java
+++ b/neo4j-bolt-connection-pooled/src/main/java/org/neo4j/bolt/connection/pooled/PooledBoltConnectionSource.java
@@ -548,13 +548,10 @@ public class PooledBoltConnectionSource implements BoltConnectionSource<BoltConn
                     }
                     iterator.remove();
                 }
-                this.closeStage = this.closeStage
-                        .thenCompose(ignored -> boltConnectionProvider.close())
-                        .exceptionally(throwable -> null)
-                        .whenComplete((ignored, throwable) -> {
-                            executorService.shutdown();
-                            closeObservation.stop();
-                        });
+                this.closeStage = this.closeStage.whenComplete((ignored, throwable) -> {
+                    executorService.shutdown();
+                    closeObservation.stop();
+                });
             }
             closeStage = this.closeStage;
         }

--- a/neo4j-bolt-connection-pooled/src/test/java/org/neo4j/bolt/connection/pooled/PooledBoltConnectionSourceTest.java
+++ b/neo4j-bolt-connection-pooled/src/test/java/org/neo4j/bolt/connection/pooled/PooledBoltConnectionSourceTest.java
@@ -26,6 +26,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.MockitoAnnotations.openMocks;
 
@@ -348,7 +349,7 @@ class PooledBoltConnectionSourceTest {
 
         // then
         then(connection).should().close();
-        then(upstreamProvider).should().close();
+        then(upstreamProvider).should(never()).close();
     }
 
     @Test

--- a/neo4j-bolt-connection-query-api/pom.xml
+++ b/neo4j-bolt-connection-query-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.neo4j.bolt</groupId>
         <artifactId>neo4j-bolt-connection-parent</artifactId>
-        <version>10.1-SNAPSHOT</version>
+        <version>11.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>neo4j-bolt-connection-query-api</artifactId>

--- a/neo4j-bolt-connection-routed/pom.xml
+++ b/neo4j-bolt-connection-routed/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.neo4j.bolt</groupId>
         <artifactId>neo4j-bolt-connection-parent</artifactId>
-        <version>10.1-SNAPSHOT</version>
+        <version>11.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>neo4j-bolt-connection-routed</artifactId>

--- a/neo4j-bolt-connection-test-values/pom.xml
+++ b/neo4j-bolt-connection-test-values/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.neo4j.bolt</groupId>
         <artifactId>neo4j-bolt-connection-parent</artifactId>
-        <version>10.1-SNAPSHOT</version>
+        <version>11.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>neo4j-bolt-connection-test-values</artifactId>

--- a/neo4j-bolt-connection/pom.xml
+++ b/neo4j-bolt-connection/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.neo4j.bolt</groupId>
         <artifactId>neo4j-bolt-connection-parent</artifactId>
-        <version>10.1-SNAPSHOT</version>
+        <version>11.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>neo4j-bolt-connection</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.neo4j.bolt</groupId>
     <artifactId>neo4j-bolt-connection-parent</artifactId>
-    <version>10.1-SNAPSHOT</version>
+    <version>11.0-SNAPSHOT</version>
 
     <packaging>pom</packaging>
     <name>Neo4j Bolt Connection</name>


### PR DESCRIPTION
BREAKING CHANGE: `BoltConnectionProvider` lifecycle is managed outside `PooledBoltConnectionSource`, so `PooledBoltConnectionSource` will not close it.