### PR TITLE
fix(ssl): Strip carriage returns from PEM cert files for BC FIPS compatibility

### DIFF
--- a/neo4j-bolt-connection/src/main/java/org/neo4j/bolt/connection/ssl/CertificateTool.java
+++ b/neo4j-bolt-connection/src/main/java/org/neo4j/bolt/connection/ssl/CertificateTool.java
@@ -19,7 +19,9 @@ package org.neo4j.bolt.connection.ssl;
 import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.FilterInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.security.GeneralSecurityException;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
@@ -43,7 +45,7 @@ final class CertificateTool {
             throws GeneralSecurityException, IOException {
         var certCount = 0; // The files might contain multiple certs
         for (var certFile : certFiles) {
-            try (var inputStream = new BufferedInputStream(new FileInputStream(certFile))) {
+            try (var inputStream = new BufferedInputStream(stripCarriageReturns(new FileInputStream(certFile)))) {
                 var certFactory = CertificateFactory.getInstance("X.509");
 
                 while (inputStream.available() > 0) {
@@ -76,6 +78,44 @@ final class CertificateTool {
 
     private static void loadX509Cert(Certificate cert, String certAlias, KeyStore keyStore) throws KeyStoreException {
         keyStore.setCertificateEntry(certAlias, cert);
+    }
+
+    /**
+     * Wraps an InputStream to strip carriage return ({@code \r}) characters.
+     * <p>
+     * PEM files created on Windows use {@code \r\n} line endings. Some security providers
+     * (notably Bouncy Castle FIPS) do not tolerate {@code \r} characters in PEM streams
+     * and throw {@link CertificateException} with "Unexpected data detected in stream".
+     * The standard JDK CertificateFactory handles {@code \r\n} without issue, but this
+     * normalization ensures compatibility across all providers.
+     */
+    private static InputStream stripCarriageReturns(InputStream inputStream) {
+        return new FilterInputStream(inputStream) {
+            @Override
+            public int read() throws IOException {
+                int b;
+                do {
+                    b = super.read();
+                } while (b == '\r');
+                return b;
+            }
+
+            @Override
+            public int read(byte[] buf, int off, int len) throws IOException {
+                var bytesRead = super.read(buf, off, len);
+                if (bytesRead <= 0) {
+                    return bytesRead;
+                }
+                var writePos = off;
+                for (var i = off; i < off + bytesRead; i++) {
+                    if (buf[i] != '\r') {
+                        buf[writePos++] = buf[i];
+                    }
+                }
+                var filtered = writePos - off;
+                return filtered > 0 ? filtered : read(buf, off, len);
+            }
+        };
     }
 
     private CertificateTool() {}

--- a/neo4j-bolt-connection/src/test/java/org/neo4j/bolt/connection/ssl/CertificateToolTest.java
+++ b/neo4j-bolt-connection/src/test/java/org/neo4j/bolt/connection/ssl/CertificateToolTest.java
@@ -72,6 +72,56 @@ class CertificateToolTest {
     }
 
     @Test
+    void shouldLoadCertWithWindowsLineEndings() throws Throwable {
+        // Given - a cert file with \r\n (Windows) line endings
+        var certFile = File.createTempFile("windows-line-endings", ".cer");
+        certFile.deleteOnExit();
+
+        var cert = generateSelfSignedCertificate();
+
+        // Write the cert with \r\n line endings to simulate a Windows-created PEM
+        saveX509CertWithWindowsLineEndings(cert, certFile);
+
+        var keyStore = KeyStore.getInstance("JKS");
+        keyStore.load(null, null);
+
+        // When
+        CertificateTool.loadX509Cert(Collections.singletonList(certFile), keyStore);
+
+        // Then
+        var aliases = keyStore.aliases();
+        assertTrue(aliases.hasMoreElements());
+        assertTrue(aliases.nextElement().startsWith("neo4j.javadriver.trustedcert"));
+        assertFalse(aliases.hasMoreElements());
+    }
+
+    @Test
+    void shouldLoadMultipleCertsWithWindowsLineEndings() throws Throwable {
+        // Given - multiple certs in a single file with \r\n line endings
+        var certFile = File.createTempFile("windows-multi-cert", ".cer");
+        certFile.deleteOnExit();
+
+        var cert1 = generateSelfSignedCertificate();
+        var cert2 = generateSelfSignedCertificate();
+
+        saveX509CertWithWindowsLineEndings(new Certificate[] {cert1, cert2}, certFile);
+
+        var keyStore = KeyStore.getInstance("JKS");
+        keyStore.load(null, null);
+
+        // When
+        CertificateTool.loadX509Cert(Collections.singletonList(certFile), keyStore);
+
+        // Then
+        var aliases = keyStore.aliases();
+        assertTrue(aliases.hasMoreElements());
+        assertTrue(aliases.nextElement().startsWith("neo4j.javadriver.trustedcert"));
+        assertTrue(aliases.hasMoreElements());
+        assertTrue(aliases.nextElement().startsWith("neo4j.javadriver.trustedcert"));
+        assertFalse(aliases.hasMoreElements());
+    }
+
+    @Test
     void shouldLoadMultipleCertsIntoKeyStore() throws Throwable {
         // Given
         var certFile = File.createTempFile("3random", ".cer");
@@ -162,6 +212,25 @@ class CertificateToolTest {
 
                 writer.write(END_CERT);
                 writer.newLine();
+            }
+        }
+    }
+
+    private static void saveX509CertWithWindowsLineEndings(Certificate cert, File certFile)
+            throws GeneralSecurityException, IOException {
+        saveX509CertWithWindowsLineEndings(new Certificate[] {cert}, certFile);
+    }
+
+    private static void saveX509CertWithWindowsLineEndings(Certificate[] certs, File certFile)
+            throws GeneralSecurityException, IOException {
+        try (var stream = new java.io.FileOutputStream(certFile)) {
+            for (var cert : certs) {
+                var certStr =
+                        Base64.getEncoder().encodeToString(cert.getEncoded()).replaceAll("(.{64})", "$1\r\n");
+
+                stream.write((BEGIN_CERT + "\r\n").getBytes());
+                stream.write((certStr + "\r\n").getBytes());
+                stream.write((END_CERT + "\r\n").getBytes());
             }
         }
     }


### PR DESCRIPTION
## Summary
- PEM certificate files created on Windows use `\r\n` line endings. Bouncy Castle FIPS `CertificateFactory.generateCertificate()` does not tolerate `\r` characters and throws `CertificateException: Unexpected data detected in stream`. The standard JDK `CertificateFactory` handles `\r\n` without issue.
- This wraps the `FileInputStream` in `CertificateTool.loadX509Cert()` with a `FilterInputStream` that strips `\r` characters, ensuring compatibility across all security providers including BC FIPS.

## Context
This was discovered in a FIPS-enabled environment where the Neo4j Kafka Connector failed to load customer-provided PEM certificates that had Windows line endings. The BC FIPS security provider is stricter than the standard JDK implementation regarding `\r` characters in PEM streams.

## Test plan
- [x] Added `shouldLoadCertWithWindowsLineEndings` — single cert with `\r\n` loads successfully
- [x] Added `shouldLoadMultipleCertsWithWindowsLineEndings` — multiple certs with `\r\n` load successfully
- [x] Existing `shouldLoadMultipleCertsIntoKeyStore` continues to pass