### PR TITLE
fix(netty): unpack DateTimeZoneId with valid zone handling

### DIFF
--- a/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/messaging/common/CommonValueUnpacker.java
+++ b/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/messaging/common/CommonValueUnpacker.java
@@ -455,10 +455,8 @@ public class CommonValueUnpacker implements ValueUnpacker {
         return ZonedDateTime.of(localDateTime, zoneId);
     }
 
-    private ZonedDateTime newZonedDateTimeUsingUtcBaseline(long epochSecondLocal, int nano, ZoneId zoneId) {
-        var instant = Instant.ofEpochSecond(epochSecondLocal, nano);
-        var localDateTime = LocalDateTime.ofInstant(instant, zoneId);
-        return ZonedDateTime.of(localDateTime, zoneId);
+    ZonedDateTime newZonedDateTimeUsingUtcBaseline(long epochSecondLocal, int nano, ZoneId zoneId) {
+        return Instant.ofEpochSecond(epochSecondLocal, nano).atZone(zoneId);
     }
 
     private BoltProtocolException instantiateExceptionForUnknownType(byte type) {

--- a/neo4j-bolt-connection-netty/src/test/java/org/neo4j/bolt/connection/netty/impl/messaging/common/CommonValueUnpackerTest.java
+++ b/neo4j-bolt-connection-netty/src/test/java/org/neo4j/bolt/connection/netty/impl/messaging/common/CommonValueUnpackerTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.bolt.connection.netty.impl.messaging.common;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import org.junit.jupiter.api.Test;
+
+final class CommonValueUnpackerTest {
+    @Test
+    void shouldMakeZonedDateTimeUsingUtcBaseline() {
+        var unpacker = new CommonValueUnpacker(mock(), true, mock());
+        var epochSecondLocal = 1761442200L;
+        var nano = 0;
+        var zoneId = ZoneId.of("Europe/Stockholm");
+
+        var date = unpacker.newZonedDateTimeUsingUtcBaseline(epochSecondLocal, nano, zoneId);
+
+        assertEquals(ZonedDateTime.parse("2025-10-26T02:30:00+01:00[Europe/Stockholm]"), date);
+    }
+}


### PR DESCRIPTION
This update fixes a bug where an incorrect `ZonedDateTime` could be returned, especially during DST periods.