### PR TITLE
Make netty-pipeline configurable

### DIFF
--- a/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/NettyBoltConnectionProviderFactory.java
+++ b/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/NettyBoltConnectionProviderFactory.java
@@ -37,6 +37,8 @@ import org.neo4j.bolt.connection.LoggingProvider;
 import org.neo4j.bolt.connection.RoutedBoltConnectionParameters;
 import org.neo4j.bolt.connection.netty.impl.NettyBoltConnectionProvider;
 import org.neo4j.bolt.connection.netty.impl.Scheme;
+import org.neo4j.bolt.connection.netty.impl.async.connection.ChannelPipelineBuilderProvider;
+import org.neo4j.bolt.connection.netty.impl.async.connection.DefaultChannelPipelineBuilderProvider;
 import org.neo4j.bolt.connection.netty.impl.async.connection.EventLoopGroupFactory;
 import org.neo4j.bolt.connection.netty.impl.async.connection.NettyTransport;
 import org.neo4j.bolt.connection.observation.ObservationProvider;
@@ -154,6 +156,12 @@ public final class NettyBoltConnectionProviderFactory implements BoltConnectionP
         Set<BoltCapability> preferredCapabilities =
                 getConfigEntry(logger, additionalConfig, "preferredCapabilities", Set.class, Set::of);
         var preferredCapabilitiesMask = toBoltCapabilitiesMask(preferredCapabilities);
+        var channelPipelineBuilderProvider = getConfigEntry(
+                logger,
+                additionalConfig,
+                "channelPipelineBuilderProvider",
+                ChannelPipelineBuilderProvider.class,
+                DefaultChannelPipelineBuilderProvider::new);
 
         return new NettyBoltConnectionProvider(
                 eventLoopGroup,
@@ -167,7 +175,8 @@ public final class NettyBoltConnectionProviderFactory implements BoltConnectionP
                 loggingProvider,
                 valueFactory,
                 shutdownEventLoopGroupOnClose,
-                observationProvider);
+                observationProvider,
+                channelPipelineBuilderProvider);
     }
 
     private EventLoopGroupFactory createEventLoopGroupFactory(

--- a/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/ConnectionProvider.java
+++ b/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/ConnectionProvider.java
@@ -23,6 +23,7 @@ import java.util.concurrent.CompletionStage;
 import org.neo4j.bolt.connection.BoltAgent;
 import org.neo4j.bolt.connection.NotificationConfig;
 import org.neo4j.bolt.connection.SecurityPlan;
+import org.neo4j.bolt.connection.netty.impl.async.connection.ChannelPipelineBuilderProvider;
 import org.neo4j.bolt.connection.netty.impl.spi.Connection;
 import org.neo4j.bolt.connection.observation.ImmutableObservation;
 import org.neo4j.bolt.connection.values.Value;
@@ -40,5 +41,6 @@ public interface ConnectionProvider {
             long initialisationTimeoutMillis,
             CompletableFuture<Long> latestAuthMillisFuture,
             NotificationConfig notificationConfig,
-            ImmutableObservation parentObservation);
+            ImmutableObservation parentObservation,
+            ChannelPipelineBuilderProvider channelPipelineBuilderProvider);
 }

--- a/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/ConnectionProviders.java
+++ b/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/ConnectionProviders.java
@@ -22,6 +22,7 @@ import java.time.Clock;
 import org.neo4j.bolt.connection.BoltProtocolVersion;
 import org.neo4j.bolt.connection.DomainNameResolver;
 import org.neo4j.bolt.connection.LoggingProvider;
+import org.neo4j.bolt.connection.netty.impl.async.connection.ChannelPipelineBuilderProvider;
 import org.neo4j.bolt.connection.netty.impl.async.connection.NettyTransport;
 import org.neo4j.bolt.connection.observation.ObservationProvider;
 import org.neo4j.bolt.connection.values.ValueFactory;
@@ -38,7 +39,8 @@ public class ConnectionProviders {
             long preferredCapabilitiesMask,
             LoggingProvider logging,
             ValueFactory valueFactory,
-            ObservationProvider observationProvider) {
+            ObservationProvider observationProvider,
+            ChannelPipelineBuilderProvider channelPipelineBuilderProvider) {
         return new NettyConnectionProvider(
                 group,
                 nettyTransport,
@@ -50,6 +52,7 @@ public class ConnectionProviders {
                 preferredCapabilitiesMask,
                 logging,
                 valueFactory,
-                observationProvider);
+                observationProvider,
+                channelPipelineBuilderProvider);
     }
 }

--- a/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/NettyBoltConnectionProvider.java
+++ b/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/NettyBoltConnectionProvider.java
@@ -36,6 +36,7 @@ import org.neo4j.bolt.connection.LoggingProvider;
 import org.neo4j.bolt.connection.NotificationConfig;
 import org.neo4j.bolt.connection.SecurityPlan;
 import org.neo4j.bolt.connection.exception.MinVersionAcquisitionException;
+import org.neo4j.bolt.connection.netty.impl.async.connection.ChannelPipelineBuilderProvider;
 import org.neo4j.bolt.connection.netty.impl.async.connection.NettyTransport;
 import org.neo4j.bolt.connection.netty.impl.util.FutureUtil;
 import org.neo4j.bolt.connection.observation.ImmutableObservation;
@@ -51,6 +52,7 @@ public final class NettyBoltConnectionProvider implements BoltConnectionProvider
     private final ValueFactory valueFactory;
     private final boolean shutdownEventLoopGroupOnClose;
     private final ObservationProvider observationProvider;
+    private final ChannelPipelineBuilderProvider channelPipelineBuilderProvider;
 
     private CompletableFuture<Void> closeFuture;
 
@@ -66,7 +68,8 @@ public final class NettyBoltConnectionProvider implements BoltConnectionProvider
             LoggingProvider logging,
             ValueFactory valueFactory,
             boolean shutdownEventLoopGroupOnClose,
-            ObservationProvider observationProvider) {
+            ObservationProvider observationProvider,
+            ChannelPipelineBuilderProvider channelPipelineBuilderProvider) {
         Objects.requireNonNull(eventLoopGroup);
         this.clock = Objects.requireNonNull(clock);
         this.logging = Objects.requireNonNull(logging);
@@ -83,11 +86,13 @@ public final class NettyBoltConnectionProvider implements BoltConnectionProvider
                 preferredCapabilitiesMask,
                 logging,
                 valueFactory,
-                observationProvider);
+                observationProvider,
+                channelPipelineBuilderProvider);
         this.valueFactory = Objects.requireNonNull(valueFactory);
         InternalLoggerFactory.setDefaultFactory(new NettyLogging(logging));
         this.shutdownEventLoopGroupOnClose = shutdownEventLoopGroupOnClose;
         this.observationProvider = Objects.requireNonNull(observationProvider);
+        this.channelPipelineBuilderProvider = Objects.requireNonNull(channelPipelineBuilderProvider);
     }
 
     @Override
@@ -134,7 +139,8 @@ public final class NettyBoltConnectionProvider implements BoltConnectionProvider
                         initialisationTimeoutMillis,
                         latestAuthMillisFuture,
                         notificationConfig,
-                        parentObservation)
+                        parentObservation,
+                        channelPipelineBuilderProvider)
                 .thenCompose(connection -> {
                     if (minVersion != null
                             && minVersion.compareTo(connection.protocol().version()) > 0) {

--- a/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/NettyConnectionProvider.java
+++ b/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/NettyConnectionProvider.java
@@ -46,7 +46,7 @@ import org.neo4j.bolt.connection.SecurityPlan;
 import org.neo4j.bolt.connection.exception.BoltClientException;
 import org.neo4j.bolt.connection.netty.impl.async.NetworkConnection;
 import org.neo4j.bolt.connection.netty.impl.async.connection.ChannelConnectedListener;
-import org.neo4j.bolt.connection.netty.impl.async.connection.ChannelPipelineBuilderImpl;
+import org.neo4j.bolt.connection.netty.impl.async.connection.ChannelPipelineBuilderProvider;
 import org.neo4j.bolt.connection.netty.impl.async.connection.NettyChannelInitializer;
 import org.neo4j.bolt.connection.netty.impl.async.connection.NettyDomainNameResolverGroup;
 import org.neo4j.bolt.connection.netty.impl.async.connection.NettyTransport;
@@ -72,6 +72,7 @@ public final class NettyConnectionProvider implements ConnectionProvider {
     private final LoggingProvider logging;
     private final ValueFactory valueFactory;
     private final ObservationProvider observationProvider;
+    private final ChannelPipelineBuilderProvider channelPipelineBuilderProvider;
 
     public NettyConnectionProvider(
             EventLoopGroup eventLoopGroup,
@@ -84,7 +85,8 @@ public final class NettyConnectionProvider implements ConnectionProvider {
             long preferredCapabilitiesMask,
             LoggingProvider logging,
             ValueFactory valueFactory,
-            ObservationProvider observationProvider) {
+            ObservationProvider observationProvider,
+            ChannelPipelineBuilderProvider channelPipelineBuilderProvider) {
         this.eventLoopGroup = eventLoopGroup;
         this.nettyTransport = Objects.requireNonNull(nettyTransport);
         this.clock = requireNonNull(clock);
@@ -97,6 +99,7 @@ public final class NettyConnectionProvider implements ConnectionProvider {
         this.logging = logging;
         this.valueFactory = requireNonNull(valueFactory);
         this.observationProvider = Objects.requireNonNull(observationProvider);
+        this.channelPipelineBuilderProvider = Objects.requireNonNull(channelPipelineBuilderProvider);
     }
 
     @Override
@@ -111,7 +114,8 @@ public final class NettyConnectionProvider implements ConnectionProvider {
             long initialisationTimeoutMillis,
             CompletableFuture<Long> latestAuthMillisFuture,
             NotificationConfig notificationConfig,
-            ImmutableObservation parentObservation) {
+            ImmutableObservation parentObservation,
+            ChannelPipelineBuilderProvider channelPipelineBuilderProvider) {
         // extract address from the URI
         BoltServerAddress uriAddress;
         var boltUnixScheme = Scheme.BOLT_UNIX_SCHEME.equals(uri.getScheme());
@@ -225,7 +229,7 @@ public final class NettyConnectionProvider implements ConnectionProvider {
         // add listener that sends Bolt handshake bytes when channel is connected
         channelConnected.addListener(new ChannelConnectedListener(
                 address,
-                new ChannelPipelineBuilderImpl(),
+                channelPipelineBuilderProvider.channelPipeline(),
                 handshakeCompleted,
                 maxVersion,
                 preferredCapabilitiesMask,

--- a/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/async/connection/ChannelPipelineBuilderProvider.java
+++ b/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/async/connection/ChannelPipelineBuilderProvider.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.bolt.connection.netty.impl.async.connection;
+
+public interface ChannelPipelineBuilderProvider {
+
+    ChannelPipelineBuilder channelPipeline();
+}

--- a/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/async/connection/DefaultChannelPipelineBuilderProvider.java
+++ b/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/async/connection/DefaultChannelPipelineBuilderProvider.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.bolt.connection.netty.impl.async.connection;
+
+public class DefaultChannelPipelineBuilderProvider implements ChannelPipelineBuilderProvider {
+    @Override
+    public ChannelPipelineBuilder channelPipeline() {
+        return new ChannelPipelineBuilderImpl();
+    }
+}


### PR DESCRIPTION
Introduces a new `ChannelPipelineBuilderProvider` which allows for injections of custom netty pipelines. This is targeted for user on implementations which are on the same JVM and avoids the overhead of POJO->byte[]->POJO overhead.