### PR TITLE
feat(bolt protocol version preselection): Make bolt protocol version selectable

### DIFF
--- a/neo4j-bolt-connection-bom/pom.xml
+++ b/neo4j-bolt-connection-bom/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.neo4j.bolt</groupId>
         <artifactId>neo4j-bolt-connection-parent</artifactId>
-        <version>11.0-SNAPSHOT</version>
+        <version>11.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>neo4j-bolt-connection-bom</artifactId>

--- a/neo4j-bolt-connection-netty/pom.xml
+++ b/neo4j-bolt-connection-netty/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.neo4j.bolt</groupId>
         <artifactId>neo4j-bolt-connection-parent</artifactId>
-        <version>11.0-SNAPSHOT</version>
+        <version>11.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>neo4j-bolt-connection-netty</artifactId>

--- a/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/NettyBoltConnectionProviderFactory.java
+++ b/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/NettyBoltConnectionProviderFactory.java
@@ -91,6 +91,11 @@ import org.neo4j.bolt.connection.values.ValueFactory;
  *     <li> <b>preferredCapabilities</b> - A {@link Set} of preferred {@link BoltCapability} that should be
  *     selected when server offers support for them during Bolt handshake. This set or individual entries in the set are
  *     ignored when no support is available or handshake does not support this feature at all.</li>
+ *     <li><b>boltProtocolVersion</b> - Sets the bolt protocol used for communication bypassing the handshake mechanism.
+ *     Defaults to {@link  BoltProtocolUtil#NO_PROTOCOL_VERSION} which enables the handshake.</li>
+ *     <li><b>channelPipelineBuilderProvider</b> - Sets a channel pipeline which can be used for custom bolt message
+ *     serialization overriding the default packstream implementation.
+ *     Defaults to {@link DefaultChannelPipelineBuilderProvider}. </li>
  * </ul>
  *
  * @since 4.0.0

--- a/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/NettyBoltConnectionProviderFactory.java
+++ b/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/NettyBoltConnectionProviderFactory.java
@@ -37,6 +37,7 @@ import org.neo4j.bolt.connection.LoggingProvider;
 import org.neo4j.bolt.connection.RoutedBoltConnectionParameters;
 import org.neo4j.bolt.connection.netty.impl.NettyBoltConnectionProvider;
 import org.neo4j.bolt.connection.netty.impl.Scheme;
+import org.neo4j.bolt.connection.netty.impl.async.connection.BoltProtocolUtil;
 import org.neo4j.bolt.connection.netty.impl.async.connection.ChannelPipelineBuilderProvider;
 import org.neo4j.bolt.connection.netty.impl.async.connection.DefaultChannelPipelineBuilderProvider;
 import org.neo4j.bolt.connection.netty.impl.async.connection.EventLoopGroupFactory;
@@ -162,6 +163,12 @@ public final class NettyBoltConnectionProviderFactory implements BoltConnectionP
                 "channelPipelineBuilderProvider",
                 ChannelPipelineBuilderProvider.class,
                 DefaultChannelPipelineBuilderProvider::new);
+        var preselectedVersion = getConfigEntry(
+                logger,
+                additionalConfig,
+                "boltProtocolVersion",
+                BoltProtocolVersion.class,
+                () -> BoltProtocolUtil.NO_PROTOCOL_VERSION);
 
         return new NettyBoltConnectionProvider(
                 eventLoopGroup,
@@ -176,7 +183,8 @@ public final class NettyBoltConnectionProviderFactory implements BoltConnectionP
                 valueFactory,
                 shutdownEventLoopGroupOnClose,
                 observationProvider,
-                channelPipelineBuilderProvider);
+                channelPipelineBuilderProvider,
+                preselectedVersion);
     }
 
     private EventLoopGroupFactory createEventLoopGroupFactory(

--- a/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/ConnectionProvider.java
+++ b/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/ConnectionProvider.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import org.neo4j.bolt.connection.BoltAgent;
+import org.neo4j.bolt.connection.BoltProtocolVersion;
 import org.neo4j.bolt.connection.NotificationConfig;
 import org.neo4j.bolt.connection.SecurityPlan;
 import org.neo4j.bolt.connection.netty.impl.async.connection.ChannelPipelineBuilderProvider;
@@ -42,5 +43,6 @@ public interface ConnectionProvider {
             CompletableFuture<Long> latestAuthMillisFuture,
             NotificationConfig notificationConfig,
             ImmutableObservation parentObservation,
-            ChannelPipelineBuilderProvider channelPipelineBuilderProvider);
+            ChannelPipelineBuilderProvider channelPipelineBuilderProvider,
+            BoltProtocolVersion preselectedBoltVersion);
 }

--- a/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/NettyBoltConnectionProvider.java
+++ b/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/NettyBoltConnectionProvider.java
@@ -53,6 +53,7 @@ public final class NettyBoltConnectionProvider implements BoltConnectionProvider
     private final boolean shutdownEventLoopGroupOnClose;
     private final ObservationProvider observationProvider;
     private final ChannelPipelineBuilderProvider channelPipelineBuilderProvider;
+    private final BoltProtocolVersion preselectedVersion;
 
     private CompletableFuture<Void> closeFuture;
 
@@ -69,7 +70,8 @@ public final class NettyBoltConnectionProvider implements BoltConnectionProvider
             ValueFactory valueFactory,
             boolean shutdownEventLoopGroupOnClose,
             ObservationProvider observationProvider,
-            ChannelPipelineBuilderProvider channelPipelineBuilderProvider) {
+            ChannelPipelineBuilderProvider channelPipelineBuilderProvider,
+            BoltProtocolVersion preselectedVersion) {
         Objects.requireNonNull(eventLoopGroup);
         this.clock = Objects.requireNonNull(clock);
         this.logging = Objects.requireNonNull(logging);
@@ -93,6 +95,7 @@ public final class NettyBoltConnectionProvider implements BoltConnectionProvider
         this.shutdownEventLoopGroupOnClose = shutdownEventLoopGroupOnClose;
         this.observationProvider = Objects.requireNonNull(observationProvider);
         this.channelPipelineBuilderProvider = Objects.requireNonNull(channelPipelineBuilderProvider);
+        this.preselectedVersion = Objects.requireNonNull(preselectedVersion);
     }
 
     @Override
@@ -140,7 +143,8 @@ public final class NettyBoltConnectionProvider implements BoltConnectionProvider
                         latestAuthMillisFuture,
                         notificationConfig,
                         parentObservation,
-                        channelPipelineBuilderProvider)
+                        channelPipelineBuilderProvider,
+                        preselectedVersion)
                 .thenCompose(connection -> {
                     if (minVersion != null
                             && minVersion.compareTo(connection.protocol().version()) > 0) {

--- a/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/NettyConnectionProvider.java
+++ b/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/NettyConnectionProvider.java
@@ -115,7 +115,8 @@ public final class NettyConnectionProvider implements ConnectionProvider {
             CompletableFuture<Long> latestAuthMillisFuture,
             NotificationConfig notificationConfig,
             ImmutableObservation parentObservation,
-            ChannelPipelineBuilderProvider channelPipelineBuilderProvider) {
+            ChannelPipelineBuilderProvider channelPipelineBuilderProvider,
+            BoltProtocolVersion preselectedBoltVersion) {
         // extract address from the URI
         BoltServerAddress uriAddress;
         var boltUnixScheme = Scheme.BOLT_UNIX_SCHEME.equals(uri.getScheme());
@@ -184,7 +185,8 @@ public final class NettyConnectionProvider implements ConnectionProvider {
                 initialisationTimeoutMillis,
                 sslHandshakeFuture,
                 handshakeCompleted,
-                appendBoltHanshake);
+                appendBoltHanshake,
+                preselectedBoltVersion);
         return handshakeCompleted
                 .thenCompose(channel -> {
                     var boltProtocol = BoltProtocol.forChannel(channel);
@@ -223,8 +225,8 @@ public final class NettyConnectionProvider implements ConnectionProvider {
             long initialisationTimeoutMillis,
             CompletableFuture<Duration> sslHandshakeFuture,
             CompletableFuture<Channel> handshakeCompleted,
-            boolean appendBoltHanshake) {
-        var pipeline = channelConnected.channel().pipeline();
+            boolean appendBoltHanshake,
+            BoltProtocolVersion preselectedVersion) {
 
         // add listener that sends Bolt handshake bytes when channel is connected
         channelConnected.addListener(new ChannelConnectedListener(
@@ -237,6 +239,7 @@ public final class NettyConnectionProvider implements ConnectionProvider {
                 valueFactory,
                 initialisationTimeoutMillis,
                 sslHandshakeFuture,
-                appendBoltHanshake));
+                appendBoltHanshake,
+                preselectedVersion));
     }
 }

--- a/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/async/connection/ChannelConnectedListener.java
+++ b/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/async/connection/ChannelConnectedListener.java
@@ -32,6 +32,7 @@ import javax.net.ssl.SSLHandshakeException;
 import org.neo4j.bolt.connection.BoltProtocolVersion;
 import org.neo4j.bolt.connection.BoltServerAddress;
 import org.neo4j.bolt.connection.LoggingProvider;
+import org.neo4j.bolt.connection.exception.BoltClientException;
 import org.neo4j.bolt.connection.exception.BoltConnectionInitialisationTimeoutException;
 import org.neo4j.bolt.connection.exception.BoltServiceUnavailableException;
 import org.neo4j.bolt.connection.netty.impl.async.inbound.ConnectTimeoutHandler;
@@ -82,17 +83,21 @@ public class ChannelConnectedListener implements ChannelFutureListener {
         if (future.isSuccess()) {
             // we know the version already so we can bypass the handshake
             if (!preselectedVersion.equals(BoltProtocolUtil.NO_PROTOCOL_VERSION)) {
-                var protocol = forVersion(preselectedVersion);
-
-                protocolSelected(
-                        preselectedVersion,
-                        protocol.createMessageFormat(),
-                        future.channel(),
-                        pipelineBuilder,
-                        logging,
-                        valueFactory,
-                        handshakeCompletedFuture);
-                return;
+                try {
+                    var protocol = forVersion(preselectedVersion);
+                    protocolSelected(
+                            preselectedVersion,
+                            protocol.createMessageFormat(),
+                            future.channel(),
+                            pipelineBuilder,
+                            logging,
+                            valueFactory,
+                            handshakeCompletedFuture);
+                    return;
+                } catch (BoltClientException protocolUnsupportedException) {
+                    handshakeCompletedFuture.completeExceptionally(protocolUnsupportedException);
+                    return;
+                }
             }
 
             sslHandshakeFuture.whenComplete((handshakeDuration, throwable) -> {

--- a/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/async/connection/ChannelConnectedListener.java
+++ b/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/async/connection/ChannelConnectedListener.java
@@ -18,6 +18,8 @@ package org.neo4j.bolt.connection.netty.impl.async.connection;
 
 import static java.lang.String.format;
 import static org.neo4j.bolt.connection.netty.impl.async.connection.BoltProtocolUtil.handshakeString;
+import static org.neo4j.bolt.connection.netty.impl.async.connection.HandshakeHandler.protocolSelected;
+import static org.neo4j.bolt.connection.netty.impl.messaging.BoltProtocol.forVersion;
 
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
@@ -48,6 +50,7 @@ public class ChannelConnectedListener implements ChannelFutureListener {
     private final long initialisationTimeoutMillis;
     private final CompletableFuture<Duration> sslHandshakeFuture;
     private final boolean appendBoltHanshake;
+    private final BoltProtocolVersion preselectedVersion;
 
     public ChannelConnectedListener(
             BoltServerAddress address,
@@ -59,7 +62,8 @@ public class ChannelConnectedListener implements ChannelFutureListener {
             ValueFactory valueFactory,
             long initialisationTimeoutMillis,
             CompletableFuture<Duration> sslHandshakeFuture,
-            boolean appendBoltHanshake) {
+            boolean appendBoltHanshake,
+            BoltProtocolVersion preselectedVersion) {
         this.address = address;
         this.pipelineBuilder = pipelineBuilder;
         this.handshakeCompletedFuture = handshakeCompletedFuture;
@@ -70,11 +74,27 @@ public class ChannelConnectedListener implements ChannelFutureListener {
         this.initialisationTimeoutMillis = initialisationTimeoutMillis;
         this.sslHandshakeFuture = Objects.requireNonNull(sslHandshakeFuture);
         this.appendBoltHanshake = appendBoltHanshake;
+        this.preselectedVersion = preselectedVersion;
     }
 
     @Override
     public void operationComplete(ChannelFuture future) {
         if (future.isSuccess()) {
+            // we know the version already so we can bypass the handshake
+            if (!preselectedVersion.equals(BoltProtocolUtil.NO_PROTOCOL_VERSION)) {
+                var protocol = forVersion(preselectedVersion);
+
+                protocolSelected(
+                        preselectedVersion,
+                        protocol.createMessageFormat(),
+                        future.channel(),
+                        pipelineBuilder,
+                        logging,
+                        valueFactory,
+                        handshakeCompletedFuture);
+                return;
+            }
+
             sslHandshakeFuture.whenComplete((handshakeDuration, throwable) -> {
                 if (throwable != null) {
                     throwable = FutureUtil.completionExceptionCause(throwable);

--- a/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/async/connection/HandshakeHandler.java
+++ b/neo4j-bolt-connection-netty/src/main/java/org/neo4j/bolt/connection/netty/impl/async/connection/HandshakeHandler.java
@@ -161,7 +161,14 @@ public class HandshakeHandler extends ReplayingDecoder<Void> {
 
                 var protocol = protocolForVersion(serverSuggestedVersion);
                 if (protocol != null) {
-                    protocolSelected(serverSuggestedVersion, protocol.createMessageFormat(), ctx);
+                    protocolSelected(
+                            serverSuggestedVersion,
+                            protocol.createMessageFormat(),
+                            ctx.channel(),
+                            pipelineBuilder,
+                            logging,
+                            valueFactory,
+                            handshakeCompletedFuture);
                 } else {
                     handleUnknownSuggestedProtocolVersion(serverSuggestedVersion, ctx);
                 }
@@ -176,12 +183,32 @@ public class HandshakeHandler extends ReplayingDecoder<Void> {
             ctx.pipeline().remove(this);
             try {
                 var protocol = manifestHandler.complete();
-                protocolSelected(protocol.version(), protocol.createMessageFormat(), ctx);
+                protocolSelected(
+                        protocol.version(),
+                        protocol.createMessageFormat(),
+                        ctx.channel(),
+                        pipelineBuilder,
+                        logging,
+                        valueFactory,
+                        handshakeCompletedFuture);
             } catch (Throwable e) {
                 fail(ctx, e);
             }
         }
         super.channelReadComplete(ctx);
+    }
+
+    public static void protocolSelected(
+            BoltProtocolVersion version,
+            MessageFormat messageFormat,
+            Channel channel,
+            ChannelPipelineBuilder pipelineBuilder,
+            LoggingProvider logging,
+            ValueFactory valueFactory,
+            CompletableFuture<Channel> handshakeCompletedFuture) {
+        ChannelAttributes.setProtocolVersion(channel, version);
+        pipelineBuilder.build(messageFormat, channel.pipeline(), logging, valueFactory);
+        handshakeCompletedFuture.complete(channel);
     }
 
     private BoltProtocol protocolForVersion(BoltProtocolVersion version) {
@@ -190,12 +217,6 @@ public class HandshakeHandler extends ReplayingDecoder<Void> {
         } catch (BoltClientException e) {
             return null;
         }
-    }
-
-    private void protocolSelected(BoltProtocolVersion version, MessageFormat messageFormat, ChannelHandlerContext ctx) {
-        ChannelAttributes.setProtocolVersion(ctx.channel(), version);
-        pipelineBuilder.build(messageFormat, ctx.pipeline(), logging, valueFactory);
-        handshakeCompletedFuture.complete(ctx.channel());
     }
 
     private void handleUnknownSuggestedProtocolVersion(BoltProtocolVersion version, ChannelHandlerContext ctx) {

--- a/neo4j-bolt-connection-netty/src/test/java/org/neo4j/bolt/connection/netty/impl/async/connection/ChannelConnectedListenerTest.java
+++ b/neo4j-bolt-connection-netty/src/test/java/org/neo4j/bolt/connection/netty/impl/async/connection/ChannelConnectedListenerTest.java
@@ -19,6 +19,7 @@ package org.neo4j.bolt.connection.netty.impl.async.connection;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -38,8 +39,12 @@ import java.util.concurrent.CompletionException;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.neo4j.bolt.connection.BoltProtocolVersion;
+import org.neo4j.bolt.connection.exception.BoltClientException;
 import org.neo4j.bolt.connection.exception.BoltServiceUnavailableException;
 import org.neo4j.bolt.connection.netty.impl.NoopLoggingProvider;
+import org.neo4j.bolt.connection.netty.impl.async.inbound.InboundMessageDispatcher;
+import org.neo4j.bolt.connection.netty.impl.messaging.v6.BoltProtocolV6;
 import org.neo4j.bolt.connection.values.ValueFactory;
 
 class ChannelConnectedListenerTest {
@@ -110,7 +115,39 @@ class ChannelConnectedListenerTest {
         assertEquals(throwable, exception.getCause());
     }
 
-    private static ChannelConnectedListener newListener(CompletableFuture<Channel> handshakeCompletedFuture) {
+    @Test
+    void shouldHandlePreselectedBoltVersion() {
+        var handshakeCompletedFuture = new CompletableFuture<Channel>();
+        var listener = newListener(handshakeCompletedFuture, BoltProtocolV6.VERSION);
+
+        var channelConnectedPromise = channel.newPromise();
+        ChannelAttributes.setMessageDispatcher(channel, mock(InboundMessageDispatcher.class));
+        channelConnectedPromise.setSuccess();
+
+        listener.operationComplete(channelConnectedPromise);
+
+        // Handshake handler not added
+        assertNull(channel.pipeline().get(HandshakeHandler.class));
+        assertEquals(ChannelAttributes.protocolVersion(channel), BoltProtocolV6.VERSION);
+    }
+
+    @Test
+    void shouldHandlePreselectedBoltVersionNotValid() {
+        var handshakeCompletedFuture = new CompletableFuture<Channel>();
+        var listener = newListener(handshakeCompletedFuture, new BoltProtocolVersion(234, 567));
+
+        var channelConnectedPromise = channel.newPromise();
+        channelConnectedPromise.setSuccess();
+
+        listener.operationComplete(channelConnectedPromise);
+
+        assertTrue(handshakeCompletedFuture.isCompletedExceptionally());
+        Throwable exception = assertThrows(CompletionException.class, handshakeCompletedFuture::join);
+        assertInstanceOf(BoltClientException.class, exception.getCause());
+    }
+
+    private static ChannelConnectedListener newListener(
+            CompletableFuture<Channel> handshakeCompletedFuture, BoltProtocolVersion preselectedVersion) {
         return new ChannelConnectedListener(
                 LOCAL_DEFAULT,
                 new ChannelPipelineBuilderImpl(),
@@ -122,7 +159,11 @@ class ChannelConnectedListenerTest {
                 0,
                 CompletableFuture.completedFuture(Duration.ZERO),
                 true,
-                BoltProtocolUtil.NO_PROTOCOL_VERSION);
+                preselectedVersion);
+    }
+
+    private static ChannelConnectedListener newListener(CompletableFuture<Channel> handshakeCompletedFuture) {
+        return newListener(handshakeCompletedFuture, BoltProtocolUtil.NO_PROTOCOL_VERSION);
     }
 
     private record FailedPromise(Throwable failure) implements ChannelPromise {

--- a/neo4j-bolt-connection-netty/src/test/java/org/neo4j/bolt/connection/netty/impl/async/connection/ChannelConnectedListenerTest.java
+++ b/neo4j-bolt-connection-netty/src/test/java/org/neo4j/bolt/connection/netty/impl/async/connection/ChannelConnectedListenerTest.java
@@ -121,7 +121,8 @@ class ChannelConnectedListenerTest {
                 mock(ValueFactory.class),
                 0,
                 CompletableFuture.completedFuture(Duration.ZERO),
-                true);
+                true,
+                BoltProtocolUtil.NO_PROTOCOL_VERSION);
     }
 
     private record FailedPromise(Throwable failure) implements ChannelPromise {

--- a/neo4j-bolt-connection-pooled/pom.xml
+++ b/neo4j-bolt-connection-pooled/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.neo4j.bolt</groupId>
         <artifactId>neo4j-bolt-connection-parent</artifactId>
-        <version>11.0-SNAPSHOT</version>
+        <version>11.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>neo4j-bolt-connection-pooled</artifactId>

--- a/neo4j-bolt-connection-query-api/pom.xml
+++ b/neo4j-bolt-connection-query-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.neo4j.bolt</groupId>
         <artifactId>neo4j-bolt-connection-parent</artifactId>
-        <version>11.0-SNAPSHOT</version>
+        <version>11.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>neo4j-bolt-connection-query-api</artifactId>

--- a/neo4j-bolt-connection-routed/pom.xml
+++ b/neo4j-bolt-connection-routed/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.neo4j.bolt</groupId>
         <artifactId>neo4j-bolt-connection-parent</artifactId>
-        <version>11.0-SNAPSHOT</version>
+        <version>11.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>neo4j-bolt-connection-routed</artifactId>

--- a/neo4j-bolt-connection-test-values/pom.xml
+++ b/neo4j-bolt-connection-test-values/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.neo4j.bolt</groupId>
         <artifactId>neo4j-bolt-connection-parent</artifactId>
-        <version>11.0-SNAPSHOT</version>
+        <version>11.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>neo4j-bolt-connection-test-values</artifactId>

--- a/neo4j-bolt-connection/pom.xml
+++ b/neo4j-bolt-connection/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.neo4j.bolt</groupId>
         <artifactId>neo4j-bolt-connection-parent</artifactId>
-        <version>11.0-SNAPSHOT</version>
+        <version>11.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>neo4j-bolt-connection</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.neo4j.bolt</groupId>
     <artifactId>neo4j-bolt-connection-parent</artifactId>
-    <version>11.0-SNAPSHOT</version>
+    <version>11.1-SNAPSHOT</version>
 
     <packaging>pom</packaging>
     <name>Neo4j Bolt Connection</name>


### PR DESCRIPTION
Introduces a config item for the netty connector to enable the user to select a bolt procol version without a bolt handshake.

The new parameter is `boltProtocolVersion` which accepts a `BoltProtocolVersion` that will prefconfigure the connection to that bolt protocol version and therefore bypassing the handshake. When not configured the handshake  is enabled.